### PR TITLE
Remove dead services code in Boxen::Runner

### DIFF
--- a/lib/boxen/runner.rb
+++ b/lib/boxen/runner.rb
@@ -102,16 +102,5 @@ module Boxen
     def issues?
       !config.stealth? && !config.pretend? && checkout.master?
     end
-
-
-    private
-
-    def services
-      Dir["/Library/LaunchDaemons/com.boxen.*.plist"]
-    end
-
-    def service_human_name(service)
-      service.match(/com\.boxen\.(.+)\.plist$/)[1]
-    end
   end
 end


### PR DESCRIPTION
This should've been part of 2d33c44b57f5c1d13e1d9e8b50a7ce802cf54b7f.
