### PR TITLE
Add repohost to config.rb

### DIFF
--- a/lib/boxen/config.rb
+++ b/lib/boxen/config.rb
@@ -47,6 +47,7 @@ module Boxen
         :puppetdir => config.puppetdir,
         :repodir   => config.repodir,
         :reponame  => config.reponame,
+        :repohost  => config.repohost,
         :srcdir    => config.srcdir,
         :user      => config.user
       }
@@ -221,6 +222,17 @@ module Boxen
     end
 
     attr_writer :reponame
+
+    # The repository hostname to use
+
+    def repohost
+      override = @repohost || ENV["BOXEN_REPO_HOST"]
+      return override unless override.nil?
+
+      @repohost = "github.com"
+    end
+
+    attr_writer :repohost
 
     # The directory where repos live. Default is
     # `"/Users/#{user}/src"`.

--- a/test/boxen_config_test.rb
+++ b/test/boxen_config_test.rb
@@ -193,6 +193,25 @@ class BoxenConfigTest < Boxen::Test
     assert_equal "some-org/our-boxen", @config.reponame
   end
 
+  def test_repohost
+    @config.repohost = "git.foo.com"
+    assert_equal "git.foo.com", @config.repohost
+  end
+
+  def test_repohost_blank
+    @config.repohost = nil
+    assert_equal "github.com", @config.repohost
+  end
+
+  def test_repohost_env_var
+    val = ENV['BOXEN_REPO_HOST']
+
+    ENV['BOXEN_REPO_HOST'] = 'git.foo.com'
+    assert_equal "git.foo.com", @config.repohost
+
+    ENV['BOXEN_REPO_HOST'] = val
+  end
+
   def test_srcdir
     @config.expects(:user).returns "foo"
     assert_equal "/Users/foo/src", @config.srcdir


### PR DESCRIPTION
Starts paving the way for configurable git repo hosts (ex. for the people using github enterprise). Related to boxen/puppet-boxen#8. Let me know if I'm a bonehead and there's a better way to do this. :-)

Thanks!

/cc @jbarnette
