### PR TITLE
Updates boxen dependencies due to new Github API requirements for User-Agent

### DIFF
--- a/boxen.gemspec
+++ b/boxen.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "hiera",            "~> 1.0.0"
   gem.add_dependency "highline",         "~> 1.6"
   gem.add_dependency "json_pure",        [">= 1.7.7", "< 2.0"]
-  gem.add_dependency "librarian-puppet", "~> 0.9"
+  gem.add_dependency "librarian-puppet", "~> 0.9.9"
   gem.add_dependency "octokit",          "~> 1.15"
   gem.add_dependency "puppet",           "~> 3.0"
 


### PR DESCRIPTION
Now that User-Agent is mandatory, boxen depends upon librarian-puppet 0.9.9.

https://github.com/rodjek/librarian-puppet/pull/95

This should fix https://github.com/boxen/our-boxen/issues/255
