### PR TITLE
Add CLI flags to manage individual services

### DIFF
--- a/lib/boxen/flags.rb
+++ b/lib/boxen/flags.rb
@@ -16,6 +16,10 @@ module Boxen
     attr_reader :srcdir
     attr_reader :user
 
+    attr_reader :disable_service
+    attr_reader :enable_service
+    attr_reader :restart_service
+
     # Create a new instance, optionally providing CLI `args` to
     # parse immediately.
 
@@ -30,6 +34,9 @@ module Boxen
       @report           = false
       @projects         = false
       @stealth          = false
+      @disable_service  = false
+      @enable_service   = false
+      @restart_service  = false
       @disable_services = false
       @enable_services  = false
       @restart_services = false
@@ -59,15 +66,27 @@ module Boxen
           @help = true
         end
 
-        o.on "--disable-services", "Disable Boxen services." do
+        o.on "--disable-service SERVICE", "Disable a Boxen service." do |service|
+          @disable_service = service
+        end
+
+        o.on "--enable-service SERVICE", "Enable a Boxen service." do |service|
+          @enable_service = service
+        end
+
+        o.on "--restart-service SERVICE", "Restart a Boxen service." do |service|
+          @restart_service = service
+        end
+
+        o.on "--disable-services", "Disable all Boxen services." do
           @disable_services = true
         end
 
-        o.on "--enable-services", "Enable Boxen services." do
+        o.on "--enable-services", "Enable all Boxen services." do
           @enable_services = true
         end
 
-        o.on "--restart-services", "Restart Boxen services." do
+        o.on "--restart-services", "Restart all Boxen services." do
           @restart_services = true
         end
 
@@ -169,6 +188,18 @@ module Boxen
 
     def enable_services?
       @enable_services
+    end
+
+    def disable_service?
+      @disable_service
+    end
+
+    def enable_service?
+      @enable_service
+    end
+
+    def restart_service?
+      @restart_service
     end
 
     def restart_services?

--- a/lib/boxen/runner.rb
+++ b/lib/boxen/runner.rb
@@ -83,6 +83,37 @@ module Boxen
         exit
       end
 
+      # --disable-service [name] stops a service
+
+      if flags.disable_service?
+        service = Boxen::Service.new(flags.disable_service)
+        puts "Disabling #{service}..."
+        service.disable
+
+        exit
+      end
+
+      # --enable-service [name] starts a service
+
+      if flags.enable_service?
+        service = Boxen::Service.new(flags.enable_service)
+        puts "Enabling #{service}..."
+        service.enable
+
+        exit
+      end
+
+      # --restart-service [name] starts a service
+
+      if flags.restart_service?
+        service = Boxen::Service.new(flags.restart_service)
+        puts "Restarting #{service}..."
+        service.disable
+        service.enable
+
+        exit
+      end
+
       # --list-services lists all services
 
       if flags.list_services?

--- a/test/boxen_runner_test.rb
+++ b/test/boxen_runner_test.rb
@@ -40,6 +40,48 @@ class BoxenRunnerTest < Boxen::Test
     runner.report(stub('result'))
   end
 
+  def test_disable_service
+    config = Boxen::Config.new
+    flags  = Boxen::Flags.new('--disable-service', 'test')
+    runner = Boxen::Runner.new config, flags
+
+    service = mock('service', :disable => true)
+    Boxen::Service.stubs(:new).returns(service)
+
+    assert_raises(SystemExit) do
+      runner.process
+    end
+  end
+
+  def test_enable_service
+    config = Boxen::Config.new
+    flags  = Boxen::Flags.new('--enable-service', 'test')
+    runner = Boxen::Runner.new config, flags
+
+    service = mock('service', :enable => true)
+    Boxen::Service.stubs(:new).returns(service)
+
+    assert_raises(SystemExit) do
+      runner.process
+    end
+  end
+
+  def test_restart_service
+    config = Boxen::Config.new
+    flags  = Boxen::Flags.new('--restart-service', 'test')
+    runner = Boxen::Runner.new config, flags
+
+    service = mock('service')
+    service.expects(:disable).once
+    service.expects(:enable).once
+
+    Boxen::Service.stubs(:new).returns(service)
+
+    assert_raises(SystemExit) do
+      runner.process
+    end
+  end
+
   def test_disable_services
     config = Boxen::Config.new
     flags  = Boxen::Flags.new('--disable-services')


### PR DESCRIPTION
For most of my work, I don't need many of the services that are installed by boxen. This addition allows the ability to quickly disable or enable individual services using the boxen command.

Tests included. :yum:
