### PR TITLE
Add 10.9 to list of supported OS X releases

### DIFF
--- a/lib/boxen/preflight/os.rb
+++ b/lib/boxen/preflight/os.rb
@@ -1,11 +1,29 @@
 require "boxen/preflight"
 
 class Boxen::Preflight::OS < Boxen::Preflight
+  SUPPORTED_RELEASES = %w(10.8 10.9)
+
   def ok?
-    `sw_vers -productVersion`.start_with? "10.8"
+    osx? && supported_release?
   end
 
   def run
-    abort "You must be running OS X 10.8 (Mountain Lion)."
+    abort "You must be running one of the following OS X versions: #{SUPPORTED_RELEASES.join(' ')}."
+  end
+
+  private
+
+  def osx?
+    `uname -s` == "Darwin"
+  end
+
+  def supported_release?
+    SUPPORTED_RELEASES.any? do |r|
+      current_release.starts_with? r
+    end
+  end
+
+  def current_release
+    @current_release ||= `sw_vers -productVersion`
   end
 end


### PR DESCRIPTION
While I want to let people skip any arbitrary preflight check later (/cc @jbarnette) I need this support now.

This also reorganizes logic a bit to make enabling Linux support later easy as well.
