### PR TITLE
Allow OAuth token to be passed as an argument

### DIFF
--- a/lib/boxen/flags.rb
+++ b/lib/boxen/flags.rb
@@ -13,6 +13,7 @@ module Boxen
     attr_reader :logfile
     attr_reader :login
     attr_reader :password
+    attr_reader :token
     attr_reader :srcdir
     attr_reader :user
 
@@ -122,6 +123,10 @@ module Boxen
           @password = password
         end
 
+        o.on "--token TOKEN", "Your GitHub OAuth token." do |token|
+          @token = token
+        end
+
         o.on "--profile", "Profile the Puppet run." do
           @profile = true
         end
@@ -159,6 +164,7 @@ module Boxen
       config.logfile       = logfile  if logfile
       config.login         = login    if login
       config.password      = password if password
+      config.token         = token    if token
       config.pretend       = pretend?
       config.profile       = profile?
       config.future_parser = future_parser?

--- a/test/boxen_flags_test.rb
+++ b/test/boxen_flags_test.rb
@@ -13,6 +13,7 @@ class BoxenFlagsTest < Boxen::Test
       expects(:logfile=).with "logfile"
       expects(:login=).with "login"
       expects(:password=).with "password"
+      expects(:token=).with "token"
       expects(:pretend=).with true
       expects(:profile=).with true
       expects(:future_parser=).with true
@@ -29,7 +30,7 @@ class BoxenFlagsTest < Boxen::Test
       "--no-fde", "--no-pull", "--no-issue", "--noop", "--password", "password",
       "--pretend", "--profile", "--future-parser", "--report", "--projects",
       "--user", "user", "--homedir", "homedir", "--srcdir", "srcdir",
-      "--logfile", "logfile"
+      "--logfile", "logfile", "--token", "token"
 
     assert_same config, flags.apply(config)
   end
@@ -149,6 +150,19 @@ class BoxenFlagsTest < Boxen::Test
   def test_password_missing_value
     ex = assert_raises Boxen::Error do
       flags "--password"
+    end
+
+    assert_match "missing argument", ex.message
+  end
+
+  def test_token
+    assert_nil flags.token
+    assert_equal "foo", flags("--token", "foo").token
+  end
+
+  def test_token_missing_value
+    ex = assert_raises Boxen::Error do
+      flags "--token"
     end
 
     assert_match "missing argument", ex.message


### PR DESCRIPTION
Pass token as an argument to `script/boxen`.

/cc @pengwynn
