### PR TITLE
Rescue from OneTimePasswordRequired expection

### DIFF
--- a/lib/boxen/preflight/creds.rb
+++ b/lib/boxen/preflight/creds.rb
@@ -49,20 +49,18 @@ class Boxen::Preflight::Creds < Boxen::Preflight
   def get_tokens
     begin
       tmp_api.authorizations(:headers => headers)
-    rescue Octokit::Unauthorized => e
+    rescue Octokit::Unauthorized
+      abort "Sorry, I can't auth you on GitHub.",
+        "Please check your credentials and teams and give it another try."
+    rescue Octokit::OneTimePasswordRequired
       puts
-      if e.message =~ /OTP/
-        if otp.nil?
-          warn "It looks like you have two-factor auth enabled."
-        else
-          warn "That one time password didn't work. Let's try again."
-        end
-        get_otp
-        get_tokens
+      if otp.nil?
+        warn "It looks like you have two-factor auth enabled."
       else
-        abort "Sorry, I can't auth you on GitHub.",
-          "Please check your credentials and teams and give it another try."
+        warn "That one time password didn't work. Let's try again."
       end
+      get_otp
+      get_tokens
     end
   end
 

--- a/test/boxen_preflight_creds_test.rb
+++ b/test/boxen_preflight_creds_test.rb
@@ -24,7 +24,7 @@ class BoxenPreflightCredsTest < Boxen::Test
     blank_opt = {:headers => {}}
     good_otp  = {:headers => {"X-GitHub-OTP" => "123456"}}
 
-    error = Octokit::Unauthorized.new
+    error = Octokit::OneTimePasswordRequired.new
     error.stubs(:message).returns("OTP")
 
     preflight.tmp_api.expects(:authorizations).with(blank_opt).raises(error)
@@ -37,5 +37,4 @@ class BoxenPreflightCredsTest < Boxen::Test
     preflight.get_tokens
     assert_equal "123456", preflight.otp
   end
-
 end


### PR DESCRIPTION
octokit.rb now raises a specific exception when the two-factor auth is enabled.

cc @pengwynn 
