### PR TITLE
Expose S3 configurations in the config object

### DIFF
--- a/lib/boxen/config.rb
+++ b/lib/boxen/config.rb
@@ -57,7 +57,9 @@ module Boxen
         :ghurl        => config.ghurl,
         :srcdir       => config.srcdir,
         :user         => config.user,
-        :repotemplate => config.repotemplate
+        :repotemplate => config.repotemplate,
+        :s3host       => config.s3host,
+        :s3bucket     => config.s3bucket
       }
 
       file = "#{config.homedir}/config/boxen/defaults.json"
@@ -298,5 +300,23 @@ module Boxen
     end
 
     attr_writer :color
+
+    # The S3 host name. Default is `"s3.amazonaws.com"`.
+    # Respects the `BOXEN_S3_HOST` environment variable.
+
+    def s3host
+      @s3host || ENV["BOXEN_S3_HOST"] || "s3.amazonaws.com"
+    end
+
+    attr_writer :s3host
+
+    # The S3 bucket name. Default is `"boxen-downloads"`.
+    # Respects the `BOXEN_S3_BUCKET` environment variable.
+
+    def s3bucket
+      @s3bucket || ENV["BOXEN_S3_BUCKET"] || "boxen-downloads"
+    end
+
+    attr_writer :s3bucket
   end
 end

--- a/test/boxen_config_test.rb
+++ b/test/boxen_config_test.rb
@@ -347,4 +347,47 @@ class BoxenConfigTest < Boxen::Test
     assert_equal api, @config.api
     assert_equal api, @config.api  # This extra call plus the `once` on the expectation is for the ivar cache.
   end
+
+  def test_s3host
+    val = ENV["BOXEN_S3_HOST"]
+    ENV["BOXEN_S3_HOST"] = nil
+
+    assert_equal "s3.amazonaws.com", @config.s3host
+
+    @config.s3host = "example.com"
+    assert_equal "example.com", @config.s3host
+  ensure
+    ENV["BOXEN_S3_HOST"] = val
+  end
+
+  def test_s3host_env_var
+    val = ENV["BOXEN_S3_HOST"]
+
+    ENV["BOXEN_S3_HOST"] = "example.com"
+    assert_equal "example.com", @config.s3host
+
+  ensure
+    ENV["BOXEN_S3_HOST"] = val
+  end
+
+  def test_s3bucket
+    val = ENV["BOXEN_S3_BUCKET"]
+    ENV["BOXEN_S3_BUCKET"] = nil
+
+    assert_equal "boxen-downloads", @config.s3bucket
+
+    @config.s3bucket = "my-bucket"
+    assert_equal "my-bucket", @config.s3bucket
+  ensure
+    ENV["BOXEN_S3_BUCKET"] = val
+  end
+
+  def test_s3host_env_var
+    val = ENV["BOXEN_S3_BUCKET"]
+
+    ENV["BOXEN_S3_BUCKET"] = "my-bucket"
+    assert_equal "my-bucket", @config.s3bucket
+  ensure
+    ENV["BOXEN_S3_BUCKET"] = val
+  end
 end


### PR DESCRIPTION
I'm adding support to configure the S3 bucket and hosts when installing Ruby versions.

After [these changes](https://github.com/boxen/puppet-ruby/compare/6.5.0...c545a00) `rbenv install` is downloding from the configure bucket, but this is not the same when we install Ruby versions using `ruby::version` class since it execute the `rbenv install` command in a separated shell.

To make it work I need to expose these environment variables in puppet Facts to se the environment variables correctly on the `ruby::version` class.

cc @wfarr @boxen/owners 
