### PR TITLE
fetch login or password from env

### DIFF
--- a/test/boxen_preflight_creds_test.rb
+++ b/test/boxen_preflight_creds_test.rb
@@ -1,4 +1,5 @@
 require 'boxen/test'
+require 'boxen/config'
 require 'boxen/preflight/creds'
 
 class BoxenPreflightCredsTest < Boxen::Test
@@ -7,6 +8,8 @@ class BoxenPreflightCredsTest < Boxen::Test
       c.user  = 'mojombo'
       c.token = 'sekr3t!'
     end
+    ENV.delete("BOXEN_GITHUB_LOGIN")
+    ENV.delete("BOXEN_GITHUB_PASSWORD")
   end
 
   def test_basic
@@ -36,5 +39,42 @@ class BoxenPreflightCredsTest < Boxen::Test
 
     preflight.get_tokens
     assert_equal "123456", preflight.otp
+  end
+
+  def test_fetch_login_and_password_when_nothing_is_given_in_env
+    # fetches login and password by asking
+    preflight = Boxen::Preflight::Creds.new @config
+    HighLine.any_instance.expects(:ask).with("GitHub login: ").returns "l"
+    HighLine.any_instance.expects(:ask).with("GitHub password: ").returns "p"
+    preflight.send(:fetch_login_and_password)
+
+    assert_equal "l", @config.login
+    assert_equal "p", preflight.instance_variable_get(:@password)
+  end
+
+  def test_fetch_password_when_login_is_given_in_env
+    # fetches only password by asking
+    ENV["BOXEN_GITHUB_LOGIN"] = "l"
+    preflight = Boxen::Preflight::Creds.new @config
+    preflight.expects(:warn)
+    HighLine.any_instance.expects(:ask).with("GitHub login: ").never
+    HighLine.any_instance.expects(:ask).with("GitHub password: ").returns "p"
+    preflight.send(:fetch_login_and_password)
+
+    assert_equal "l", @config.login
+    assert_equal "p", preflight.instance_variable_get(:@password)
+  end
+
+  def test_fetch_login_when_password_is_given_in_env
+    # fetches only login by asking
+    ENV["BOXEN_GITHUB_PASSWORD"] = "p"
+    preflight = Boxen::Preflight::Creds.new @config
+    preflight.expects(:warn)
+    HighLine.any_instance.expects(:ask).with("GitHub login: ").returns "l"
+    HighLine.any_instance.expects(:ask).with("GitHub password: ").never
+    preflight.send(:fetch_login_and_password)
+
+    assert_equal "l", @config.login
+    assert_equal "p", preflight.instance_variable_get(:@password)
   end
 end


### PR DESCRIPTION
@pengwynn 

my machine had BOXEN_GITHUB_LOGIN set but not the password,
so the old code never asked for my password, this fixes it by asking for whatever is unknown

error I got prior looked like this:

```
--> Oh, looks like you've provided your username and password as environmental variables...

/opt/boxen/repo/.bundle/ruby/2.0.0/gems/octokit-2.3.1/lib/octokit/response/raise_error.rb:16:in `on_complete': GET https://api.github.com/authorizations?&per_page=100: 404 - Not Found // See: http://developer.github.com/v3 (Octokit::NotFound)
    from /opt/boxen/repo/.bundle/ruby/2.0.0/gems/faraday-0.8.8/lib/faraday/response.rb:9:in `block in call'
    from /opt/boxen/repo/.bundle/ruby/2.0.0/gems/faraday-0.8.8/lib/faraday/response.rb:63:in `on_complete'
    from /opt/boxen/repo/.bundle/ruby/2.0.0/gems/faraday-0.8.8/lib/faraday/response.rb:8:in `call'
    from /opt/boxen/repo/.bundle/ruby/2.0.0/gems/faraday-0.8.8/lib/faraday/connection.rb:253:in `run_request'
    from /opt/boxen/repo/.bundle/ruby/2.0.0/gems/faraday-0.8.8/lib/faraday/connection.rb:106:in `get'
    from /opt/boxen/repo/.bundle/ruby/2.0.0/gems/sawyer-0.5.1/lib/sawyer/agent.rb:94:in `call'
    from /opt/boxen/repo/.bundle/ruby/2.0.0/gems/octokit-2.3.1/lib/octokit/client.rb:243:in `request'
    from /opt/boxen/repo/.bundle/ruby/2.0.0/gems/octokit-2.3.1/lib/octokit/client.rb:186:in `paginate'
    from /opt/boxen/repo/.b
```
