### PR TITLE
Bump librarian-puppet version

### DIFF
--- a/boxen.gemspec
+++ b/boxen.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "hiera",            "~> 1.0"
   gem.add_dependency "highline",         "~> 1.6"
   gem.add_dependency "json_pure",        [">= 1.7.7", "< 2.0"]
-  gem.add_dependency "librarian-puppet", "~> 0.9.9"
+  gem.add_dependency "librarian-puppet", "~> 0.9.10"
   gem.add_dependency "octokit",          "~> 2.3.0"
   gem.add_dependency "puppet",           "~> 3.0"
 


### PR DESCRIPTION
0.9.10 has an error message for rate limiting on Github :+1:

Means it's better error message when you get rate limited :cat: 
