### PR TITLE
only start servies that were running when doing --restart-servces

### DIFF
--- a/lib/boxen/runner.rb
+++ b/lib/boxen/runner.rb
@@ -127,7 +127,7 @@ module Boxen
       # --restart-services restarts all services
 
       if flags.restart_services?
-        Boxen::Service.list.each do |service|
+        Boxen::Service.list_enabled.each do |service|
           puts "Restarting #{service}..."
           service.disable
           service.enable

--- a/lib/boxen/service.rb
+++ b/lib/boxen/service.rb
@@ -10,6 +10,13 @@ module Boxen
       end
     end
 
+    def self.list_enabled
+      prefix = /^dev\./
+      enabled = capture_output("sudo /bin/launchctl list").split("\n").map { |l| l.split(/\s/) }.map(&:last)
+      names = enabled.grep(prefix).map { |name| name.sub(prefix, "") }.compact
+      names.map { |name| new(name) }
+    end
+
     def initialize(name)
       @name = name
     end
@@ -26,8 +33,11 @@ module Boxen
       Boxen::Util.sudo('/bin/launchctl', 'unload', '-w', location)
     end
 
-
     private
+
+    def self.capture_output(command)
+      `#{command}`
+    end
 
     def location
       "#{self.class.location}/dev.#{name}.plist"

--- a/test/boxen_runner_test.rb
+++ b/test/boxen_runner_test.rb
@@ -118,7 +118,7 @@ class BoxenRunnerTest < Boxen::Test
       service.expects(:disable).once
       service.expects(:enable).once
     end
-    Boxen::Service.stubs(:list).returns(services)
+    Boxen::Service.stubs(:list_enabled).returns(services)
 
     assert_raises(SystemExit) do
       runner.process

--- a/test/boxen_service_test.rb
+++ b/test/boxen_service_test.rb
@@ -12,6 +12,12 @@ class BoxenServiceTest < Boxen::Test
     assert_equal ['other', 'test'], services.collect(&:name).sort
   end
 
+  def test_list_enabled
+    Boxen::Service.expects(:capture_output).with("sudo /bin/launchctl list").returns "foo bar dev.baz\nfoo bar bazz"
+    services = Boxen::Service.list_enabled
+    assert_equal ['baz'], services.collect(&:name)
+  end
+
   def test_enable
     service = Boxen::Service.new('blip')
     Boxen::Util.expects(:sudo).with('/bin/launchctl', 'load', '-w',


### PR DESCRIPTION
avoids starting services that were not started before
we have a bunch of optional services that should not be suddenly started when someone is trying to restart services

@fromonesrc
