### PR TITLE
Added functionality for generating dependency graphs

### DIFF
--- a/lib/boxen/config.rb
+++ b/lib/boxen/config.rb
@@ -175,6 +175,14 @@ module Boxen
 
     attr_writer :report
 
+    # Enable generation of dependency graphs.
+
+    def graph?
+      !!@graph
+    end
+
+    attr_writer :graph
+
     # An Array of Boxen::Project entries, one for each project Boxen
     # knows how to manage.
     #

--- a/lib/boxen/flags.rb
+++ b/lib/boxen/flags.rb
@@ -32,6 +32,7 @@ module Boxen
       @pretend          = false
       @profile          = false
       @report           = false
+      @graph            = false
       @projects         = false
       @stealth          = false
       @disable_service  = false
@@ -56,6 +57,10 @@ module Boxen
 
         o.on "--report", "Enable puppet reports." do
           @report = true
+        end
+
+        o.on "--graph", "Enable generation of dependency graphs." do
+          @graph = true
         end
 
         o.on "--env", "Show useful environment variables." do
@@ -163,6 +168,7 @@ module Boxen
       config.profile       = profile?
       config.future_parser = future_parser?
       config.report        = report?
+      config.graph         = graph?
       config.srcdir        = srcdir   if srcdir
       config.stealth       = stealth?
       config.user          = user     if user
@@ -241,6 +247,10 @@ module Boxen
 
     def report?
       @report
+    end
+
+    def graph?
+      @graph
     end
 
     def projects?

--- a/lib/boxen/puppeteer.rb
+++ b/lib/boxen/puppeteer.rb
@@ -61,6 +61,8 @@ module Boxen
       flags << "--no-report" unless config.report?
       flags << "--detailed-exitcodes"
 
+      flags << "--graph" if config.graph?
+
       flags << "--show_diff"
 
       if config.profile?
@@ -86,6 +88,8 @@ module Boxen
       FileUtils.rm_f config.logfile
 
       FileUtils.rm_rf "#{config.puppetdir}/var/reports" if config.report?
+
+      FileUtils.rm_rf "#{config.puppetdir}/var/state/graphs" if config.graph?
 
       FileUtils.mkdir_p File.dirname config.logfile
       FileUtils.touch config.logfile

--- a/test/boxen_flags_test.rb
+++ b/test/boxen_flags_test.rb
@@ -17,6 +17,7 @@ class BoxenFlagsTest < Boxen::Test
       expects(:profile=).with true
       expects(:future_parser=).with true
       expects(:report=).with true
+      expects(:graph=).with true
       expects(:srcdir=).with "srcdir"
       expects(:stealth=).with true
       expects(:user=).with "user"
@@ -27,7 +28,7 @@ class BoxenFlagsTest < Boxen::Test
 
     flags = Boxen::Flags.new "--debug", "--help", "--login", "login",
       "--no-fde", "--no-pull", "--no-issue", "--noop",
-      "--pretend", "--profile", "--future-parser", "--report", "--projects",
+      "--pretend", "--profile", "--future-parser", "--report", "--graph", "--projects",
       "--user", "user", "--homedir", "homedir", "--srcdir", "srcdir",
       "--logfile", "logfile", "--token", "token"
 
@@ -173,6 +174,11 @@ class BoxenFlagsTest < Boxen::Test
   def test_report
     refute flags.report?
     assert flags("--report").report?
+  end
+
+  def test_graph
+    refute flags.graph?
+    assert flags("--graph").graph?
   end
 
   def test_projects

--- a/test/boxen_puppeteer_test.rb
+++ b/test/boxen_puppeteer_test.rb
@@ -18,6 +18,7 @@ class BoxenPuppeteerTest < Boxen::Test
       stubs(:debug?).returns true
       stubs(:pretend?).returns true
       stubs(:report?).returns false
+      stubs(:graph?).returns false
       stubs(:color?).returns false
     end
 
@@ -55,6 +56,7 @@ class BoxenPuppeteerTest < Boxen::Test
       stubs(:profile?).returns false
       stubs(:future_parser?).returns false
       stubs(:report?).returns false
+      stubs(:graph?).returns false
       stubs(:puppetdir).returns "puppetdir"
       stubs(:repodir).returns "test/fixtures/repo"
       stubs(:color?).returns true


### PR DESCRIPTION
This PR adds a config option to enable the generation of dependency graphs.
If you provide the `--graph` option, dependency graphs will be generated in the `#{config.puppetdir}/var/state/graphs` directory.

Regards.
