### PR TITLE
Make hooks customisable

### DIFF
--- a/lib/boxen/hook.rb
+++ b/lib/boxen/hook.rb
@@ -45,6 +45,3 @@ end
 
 require "boxen/hook/github_issue"
 require "boxen/hook/web"
-
-Boxen::Hook.register Boxen::Hook::GitHubIssue
-Boxen::Hook.register Boxen::Hook::Web

--- a/lib/boxen/hook/github_issue.rb
+++ b/lib/boxen/hook/github_issue.rb
@@ -116,3 +116,5 @@ module Boxen
     end
   end
 end
+
+Boxen::Hook.register Boxen::Hook::GitHubIssue

--- a/lib/boxen/hook/web.rb
+++ b/lib/boxen/hook/web.rb
@@ -52,3 +52,5 @@ module Boxen
     end
   end
 end
+
+Boxen::Hook.register Boxen::Hook::Web


### PR DESCRIPTION
You can add/remove custom hooks as necessary via the `Boxen::Hook.register` and `.unregister` class methods.
