### PR TITLE
Bump librarian-puppet to use 1.0.0

### DIFF
--- a/boxen.gemspec
+++ b/boxen.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "hiera",            "~> 1.0"
   gem.add_dependency "highline",         "~> 1.6"
   gem.add_dependency "json_pure",        [">= 1.7.7", "< 2.0"]
-  gem.add_dependency "librarian-puppet", "~> 0.9.10"
+  gem.add_dependency "librarian-puppet", "~> 1.0.0"
   gem.add_dependency "octokit",          "~> 2.7", ">= 2.7.1"
   gem.add_dependency "puppet",           "~> 3.0"
 


### PR DESCRIPTION
This release is the first stable release and also remove the deprecation warning of github_tarball.

https://github.com/rodjek/librarian-puppet/compare/v0.9.17...v1.0.0

Fixes https://github.com/boxen/our-boxen/issues/568 

cc @dgoodlad 
