### PR TITLE
Fix OS X version checker

### DIFF
--- a/lib/boxen/preflight/os.rb
+++ b/lib/boxen/preflight/os.rb
@@ -18,8 +18,6 @@ class Boxen::Preflight::OS < Boxen::Preflight
   end
 
   def supported_release?
-    puts "#{current_release} >= #{MIN_VERSION}?"
-
     Gem::Version.new(current_release) >= Gem::Version.new(MIN_VERSION)
   end
 

--- a/test/boxen_preflight_os_version_test.rb
+++ b/test/boxen_preflight_os_version_test.rb
@@ -11,18 +11,18 @@ class BoxenPreflightOSTest < Boxen::Test
   def test_invalid_version
     preflight.instance_variable_set(:@current_release, '10.7.0')
 
-    assert !preflight.ok?
+    assert !preflight.send(:supported_release?)
   end
 
   def test_valid_version
     preflight.instance_variable_set(:@current_release, '10.8.0')
 
-    assert preflight.ok?
+    assert preflight.send :supported_release?
   end
 
   def test_valid_subversion
     preflight.instance_variable_set(:@current_release, '10.10.10')
 
-    assert preflight.ok?
+    assert preflight.send :supported_release?
   end
 end


### PR DESCRIPTION
As mentioned in boxen/our-boxen#612 the version checker in boxen preflight checks should make sure OS X > 10.8 instead of checking for specific minor versions.
