### PR TITLE
allow boxen runs to continue without saving config

### DIFF
--- a/lib/boxen/cli.rb
+++ b/lib/boxen/cli.rb
@@ -45,7 +45,12 @@ module Boxen
 
       # Save the config for Puppet (and next time).
 
-      Boxen::Config.save config
+      begin
+        Boxen::Config.save config
+      rescue Exception => e
+        $stderr.puts e.message
+        $stderr.puts "Warning: failed to save Boxen config. The run will continue, but no configuration will persist to your next run."
+      end
 
       # Make the magic happen.
 


### PR DESCRIPTION
From what I can tell, Boxen will always fail when it can't access the OS X keychain, even when its possible to continue running. I hit this issue when trying to run `boxen --token abc12345...` after ssh-ing in. When that happens, I see the following:

```
Boxen Keychain Helper: Encountered error code: -25308
Error: User interaction is not allowed.
Boxen Keychain Helper: Encountered error code: -25308
Error: User interaction is not allowed.
Boxen Keychain Helper: Encountered error code: -25308
Error: User interaction is not allowed.
/opt/boxen/repo/.bundle/ruby/2.0.0/gems/boxen-2.6.0/lib/boxen/keychain.rb:48:in `set': Can't save GitHub API Token in the keychain. (Boxen::Error)
        from /opt/boxen/repo/.bundle/ruby/2.0.0/gems/boxen-2.6.0/lib/boxen/keychain.rb:30:in `token='
        from /opt/boxen/repo/.bundle/ruby/2.0.0/gems/boxen-2.6.0/lib/boxen/config.rb:73:in `save'
        from /opt/boxen/repo/.bundle/ruby/2.0.0/gems/boxen-2.6.0/lib/boxen/cli.rb:48:in `run'
        from /opt/boxen/bin/boxen:80:in `<main>'
```

Even though its possible for Boxen to run successfully without saving.

My solution is to change a failed save to a warning and move forward. Perhaps its possible to do this some other way; if so, please let me know. Another approach might be a flag that allows Boxen to ignore this when set, but continuing on if possible seems like a better default to me, which is why I implemented it this way.
