### PR TITLE
Added Yosemite (10.10) to list of supported OS releases

### DIFF
--- a/lib/boxen/preflight/os.rb
+++ b/lib/boxen/preflight/os.rb
@@ -1,7 +1,7 @@
 require "boxen/preflight"
 
 class Boxen::Preflight::OS < Boxen::Preflight
-  SUPPORTED_RELEASES = %w(10.8 10.9)
+  SUPPORTED_RELEASES = %w(10.8 10.9 10.10)
 
   def ok?
     osx? && supported_release?


### PR DESCRIPTION
Hey Boxenites,

I added Yosemite (10.10) to the list of support versions in the OS preflight check. I had a poke around for any related tests, but couldn't find anything. Let me know if there's anything I missed for this PR.

Also, thanks for all your hard work on Boxen! I love it :cake: 
