### PR TITLE
Fix Puppet 3.6 or later, manifestdir is deprecated, use manifest

### DIFF
--- a/lib/boxen/puppeteer.rb
+++ b/lib/boxen/puppeteer.rb
@@ -44,7 +44,7 @@ module Boxen
       flags << ["--vardir",      "#{config.puppetdir}/var"]
       flags << ["--libdir",      "#{config.repodir}/lib"]#:#{root}/lib"]
       flags << ["--libdir",      "#{root}/lib"]
-      flags << ["--manifestdir", "#{config.repodir}/manifests"]
+      flags << ["--manifest", "#{config.repodir}/manifests"]
       flags << ["--modulepath",  "#{config.repodir}/modules:#{config.repodir}/shared"]
 
       # Don't ever complain about Hiera to me

--- a/test/boxen_puppeteer_test.rb
+++ b/test/boxen_puppeteer_test.rb
@@ -38,7 +38,7 @@ class BoxenPuppeteerTest < Boxen::Test
     assert_flag_value "--group", "admin", flags
     assert_flag_value "--vardir", :anything, flags
     assert_flag_value "--libdir", :anything, flags
-    assert_flag_value "--manifestdir", :anything, flags
+    assert_flag_value "--manifest", :anything, flags
     assert_flag_value "--modulepath", :anything, flags
 
     assert_flag_value "--hiera_config", "/dev/null", flags


### PR DESCRIPTION
Puppet (warning): Setting manifestdir is deprecated. See http://links.puppetlabs.com/env-settings-deprecations
   (at /opt/boxen/repo/.bundle/ruby/2.0.0/gems/puppet-3.6.1/lib/puppet/settings.rb:260:in `block (2 levels) in parse_global_options')
