### PR TITLE
Add "--list--updated--modules" cli option

### DIFF
--- a/lib/boxen/flags.rb
+++ b/lib/boxen/flags.rb
@@ -24,25 +24,26 @@ module Boxen
     # parse immediately.
 
     def initialize(*args)
-      @args             = []
-      @debug            = false
-      @env              = false
-      @fde              = true
-      @help             = false
-      @pretend          = false
-      @profile          = false
-      @report           = false
-      @graph            = false
-      @projects         = false
-      @stealth          = false
-      @disable_service  = false
-      @enable_service   = false
-      @restart_service  = false
-      @disable_services = false
-      @enable_services  = false
-      @restart_services = false
-      @list_services    = false
-      @color            = true
+      @args                 = []
+      @debug                = false
+      @env                  = false
+      @fde                  = true
+      @help                 = false
+      @pretend              = false
+      @profile              = false
+      @report               = false
+      @graph                = false
+      @projects             = false
+      @stealth              = false
+      @disable_service      = false
+      @enable_service       = false
+      @restart_service      = false
+      @disable_services     = false
+      @enable_services      = false
+      @restart_services     = false
+      @list_services        = false
+      @list_updated_modules = false
+      @color                = true
 
       @options = OptionParser.new do |o|
         o.banner = "Usage: #{File.basename $0} [options] [projects...]\n\n"
@@ -97,6 +98,10 @@ module Boxen
 
         o.on "--list-services", "List Boxen services." do
           @list_services = true
+        end
+
+        o.on "--list-updated-modules", "List modules with newer versions available." do
+          @list_updated_modules = true
         end
 
         o.on "--homedir DIR", "Boxen's home directory." do |homedir|
@@ -219,6 +224,10 @@ module Boxen
 
     def list_services?
       @list_services
+    end
+
+    def list_updated_modules?
+      @list_updated_modules
     end
 
     def run?

--- a/lib/boxen/runner.rb
+++ b/lib/boxen/runner.rb
@@ -114,6 +114,16 @@ module Boxen
         exit
       end
 
+      # --list-updated-modules lists updated puppet modules
+
+      if flags.list_updated_modules?
+        puts "Checking for modules with new releases (this might take awhile)..."
+        @puppet.check_for_new_puppet_modules
+
+        exit
+      end
+
+
       # --list-services lists all services
 
       if flags.list_services?

--- a/test/boxen_flags_test.rb
+++ b/test/boxen_flags_test.rb
@@ -26,12 +26,29 @@ class BoxenFlagsTest < Boxen::Test
 
     # Do our best to frob every switch.
 
-    flags = Boxen::Flags.new "--debug", "--help", "--login", "login",
-      "--no-fde", "--no-pull", "--no-issue", "--noop",
-      "--pretend", "--profile", "--future-parser", "--report", "--graph", "--projects",
-      "--user", "user", "--homedir", "homedir", "--srcdir", "srcdir",
-      "--logfile", "logfile", "--token", "token"
+    flags_list = %w(
+      --debug
+      --help
+      --login login
+      --no-fde
+      --no-pull
+      --no-issue
+      --noop
+      --pretend
+      --profile
+      --future-parser
+      --report
+      --graph
+      --projects
+      --user user
+      --homedir homedir
+      --srcdir srcdir
+      --logfile logfile
+      --token token
+      --list-updated-modules
+    )
 
+    flags = Boxen::Flags.new(flags_list)
     assert_same config, flags.apply(config)
   end
 
@@ -199,6 +216,11 @@ class BoxenFlagsTest < Boxen::Test
 
   def test_user
     assert_equal "jbarnette", flags("--user", "jbarnette").user
+  end
+
+  def test_list_updated_modules?
+    refute flags.list_updated_modules?
+    assert flags('--list-updated-modules').list_updated_modules?
   end
 
   def test_user_missing_value


### PR DESCRIPTION
One solution to this [common question](https://github.com/boxen/our-boxen/issues/275). Adds `--list-updated-modules` to the CLI to see what, if any, newer puppet module versions are available based on one's Puppetfile. Ensures Boxen's GitHub token will be temporarily set as `GITHUB_API_TOKEN` to not hit API limits. 
