### PR TITLE
Bump the librarian version number

### DIFF
--- a/boxen.gemspec
+++ b/boxen.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "hiera",            "~> 1.0"
   gem.add_dependency "highline",         "~> 1.6"
   gem.add_dependency "json_pure",        [">= 1.7.7", "< 2.0"]
-  gem.add_dependency "librarian-puppet", "~> 1.0.0"
+  gem.add_dependency "librarian-puppet", "~> 1.4.1"
   gem.add_dependency "octokit",          "~> 2.7", ">= 2.7.1"
   gem.add_dependency "puppet",           "~> 3.7"
 


### PR DESCRIPTION
Third-party puppet modules that use the metadata support in newer librarian-puppet versions are broken under boxen by the 1.0.0 semver restriction. AFAICT there's no breakage here with librarian-puppet 1.4.1. 1.4.x is the official Ruby 1.8 support line now for librarian-puppet.
