### PR TITLE
Add --no-auth flag to allow ./script/boxen to run without Github authentication

### DIFF
--- a/lib/boxen/config.rb
+++ b/lib/boxen/config.rb
@@ -48,6 +48,7 @@ module Boxen
       attrs = {
         :email        => config.email,
         :fde          => config.fde?,
+        :auth         => config.auth?,
         :homedir      => config.homedir,
         :login        => config.login,
         :name         => config.name,
@@ -79,6 +80,7 @@ module Boxen
 
     def initialize(&block)
       @fde  = true
+      @auth = true
       @pull = true
 
       yield self if block_given?
@@ -117,6 +119,15 @@ module Boxen
     end
 
     attr_writer :fde
+
+    # Run with Github authentication? Default is `true`. Respects
+    # the `BOXEN_NO_AUTH` environment variable.
+
+    def auth?
+      !ENV["BOXEN_NO_AUTH"] && @auth
+    end
+
+    attr_writer :auth
 
     # Boxen's home directory. Default is `"/opt/boxen"`. Respects the
     # `BOXEN_HOME` environment variable.

--- a/lib/boxen/flags.rb
+++ b/lib/boxen/flags.rb
@@ -28,6 +28,7 @@ module Boxen
       @debug            = false
       @env              = false
       @fde              = true
+      @auth             = true
       @help             = false
       @pretend          = false
       @profile          = false
@@ -115,6 +116,10 @@ module Boxen
           @fde = false
         end
 
+        o.on "--no-auth", "Don't require Github authentication." do
+          @auth = false
+        end
+
         # --no-pull is used before options are parsed, but consumed here.
 
         o.on "--no-pull", "Don't try to update code before applying."
@@ -160,6 +165,7 @@ module Boxen
     def apply(config)
       config.debug         = debug?
       config.fde           = fde?     if config.fde?
+      config.auth          = auth?    if config.auth?
       config.homedir       = homedir  if homedir
       config.logfile       = logfile  if logfile
       config.login         = login    if login
@@ -187,6 +193,10 @@ module Boxen
 
     def fde?
       @fde
+    end
+
+    def auth?
+      @auth
     end
 
     def help?

--- a/lib/boxen/preflight/creds.rb
+++ b/lib/boxen/preflight/creds.rb
@@ -65,6 +65,9 @@ class Boxen::Preflight::Creds < Boxen::Preflight
   end
 
   def run
+    if not config.auth?
+        return
+    end
     fetch_login_and_password
     tokens = get_tokens
 

--- a/test/boxen_config_test.rb
+++ b/test/boxen_config_test.rb
@@ -37,6 +37,22 @@ class BoxenConfigTest < Boxen::Test
     ENV["BOXEN_NO_FDE"] = val
   end
 
+  def test_auth?
+    assert @config.auth?
+
+    @config.auth = false
+    refute @config.auth?
+  end
+
+  def test_auth_env_var
+    val = ENV["BOXEN_NO_AUTH"]
+
+    ENV["BOXEN_NO_AUTH"] = "1"
+    refute @config.auth?
+
+    ENV["BOXEN_NO_AUTH"] = val
+  end
+
   def test_homedir
     val = ENV["BOXEN_HOME"]
     ENV["BOXEN_HOME"] = nil

--- a/test/boxen_flags_test.rb
+++ b/test/boxen_flags_test.rb
@@ -9,6 +9,9 @@ class BoxenFlagsTest < Boxen::Test
       stubs(:fde?).returns true
       expects(:fde=).with false
 
+      stubs(:auth?).returns true
+      expects(:auth=).with false
+
       expects(:homedir=).with "homedir"
       expects(:logfile=).with "logfile"
       expects(:login=).with "login"
@@ -27,7 +30,7 @@ class BoxenFlagsTest < Boxen::Test
     # Do our best to frob every switch.
 
     flags = Boxen::Flags.new "--debug", "--help", "--login", "login",
-      "--no-fde", "--no-pull", "--no-issue", "--noop",
+      "--no-fde", "--no-auth", "--no-pull", "--no-issue", "--noop",
       "--pretend", "--profile", "--future-parser", "--report", "--graph", "--projects",
       "--user", "user", "--homedir", "homedir", "--srcdir", "srcdir",
       "--logfile", "logfile", "--token", "token"
@@ -128,6 +131,11 @@ class BoxenFlagsTest < Boxen::Test
   def test_no_fde
     assert flags.fde?
     refute flags("--no-fde").fde?
+  end
+
+  def test_no_auth
+    assert flags.auth?
+    refute flags("--no-auth").auth?
   end
 
   def test_no_pull_is_a_noop


### PR DESCRIPTION
This change set adds the --no-auth flag, which bypasses Github authentication. This lets users without github accounts use boxen.

My specific use case is launching a Yosemite box in Vagrant and having boxen configure it. A Vagrant box by default uses a "vagrant" user, which isn't going to have a Github account. But more broadly, it would be nice to build Macbooks for non-developers using Boxen, and non-developers aren't going to have Github accounts.

```
  -> vagrant up
  ... Yosemite box comes up in Virtualbox ...
  -> vagrant sandbox on # Use the sahara plugin too
  -> vagrant ssh
  Last login: Fri Feb  6 08:22:05 2015 from linus162.gsc.wustl.edu
  osx-10_10:~ vagrant$ mkdir git && cd git
  osx-10_10:git vagrant$ git clone https://github.com/mcallaway/our-boxen.git
  Cloning into 'our-boxen'...
  remote: Counting objects: 2290, done.
  remote: Compressing objects: 100% (31/31), done.
  remote: Total 2290 (delta 3), reused 20 (delta 0)
  Receiving objects: 100% (2290/2290), 87.52 MiB | 18.86 MiB/s, done.
  Resolving deltas: 100% (937/937), done.
  Checking connectivity... done.
  osx-10_10:git vagrant$ cd our-boxen/
  osx-10_10:our-boxen vagrant$ ./script/boxen --no-fde --no-auth --debug 2>&1 | tee ~/boxen.log
  ... boxen runs ...
  Debug: Stored state in 0.02 seconds
  --> You haven't loaded Boxen's environment yet!
      To permanently fix this, source /opt/boxen/env.sh at the end
      of your shell's startup file.

  --> Run source /opt/boxen/env.sh or restart your shell for new stuff!
```

Note that tests are included:

```
-> ./script/tests
Run options: --seed 36800

# Running tests:

..............................................................................................................................
.........................S........

Finished tests in 0.242111s, 660.8539 tests/s, 1565.3977 assertions/s.

160 tests, 379 assertions, 0 failures, 0 errors, 1 skips
```
