### PR TITLE
Style fixes/updates/small refactors

### DIFF
--- a/lib/boxen/check.rb
+++ b/lib/boxen/check.rb
@@ -1,29 +1,23 @@
-require "ansi"
+require 'ansi'
 
 module Boxen
-
   # The superclass for preflight and postflight sanity checks.
-
   class Check
-
     # A collection of preflight instances for `config`. An instance is
     # created for every constant under `self` that's also a
     # subclass of `self`.
-
     def self.checks(config)
-      constants.map { |n| const_get n }.
-        select { |c| c < self }.
-        map { |c| c.new config }
+      constants.map { |n| const_get n }
+        .select { |c| c < self }
+        .map { |c| c.new config }
     end
 
     # Search `dir` and load all Ruby files under it.
-
     def self.register(dir)
       Dir["#{dir}/*.rb"].sort.each { |f| load f }
     end
 
     # Check each instance against `config`.
-
     def self.run(config)
       checks(config).each { |check| check.run unless check.ok? }
     end
@@ -35,15 +29,14 @@ module Boxen
     end
 
     # Is everything good to go? Implemented by subclasses.
-
     def ok?
-      raise "Subclasses must implement this method."
+      fail 'Subclasses must implement this method.'
     end
 
     # Warn, fix, or abort. Implemented by subclasses.
 
     def run
-      raise "Subclasses must implement this method."
+      fail 'Subclasses must implement this method.'
     end
 
     # A fancier `abort` and `warn`. This will probably really annoy
@@ -51,7 +44,7 @@ module Boxen
     # but it's limited to checks.
 
     def abort(message, *extras)
-      extras << { :color => :red }
+      extras << { color: :red }
       warn message, *extras
       exit 1
     end
@@ -62,9 +55,7 @@ module Boxen
 
       $stderr.puts ANSI.send(color) { "--> #{message}" }
 
-      unless extras.empty?
-        extras.each { |line| $stderr.puts "    #{line}" }
-      end
+      extras.each { |line| $stderr.puts "    #{line}" } unless extras.empty?
 
       $stderr.puts
     end

--- a/lib/boxen/checkout.rb
+++ b/lib/boxen/checkout.rb
@@ -11,7 +11,9 @@ module Boxen
     end
 
     def master?
-      Dir.chdir(config.repodir) { `git symbolic-ref HEAD`.strip == 'refs/heads/master' }
+      Dir.chdir(config.repodir) do
+        `git symbolic-ref HEAD`.strip == 'refs/heads/master'
+      end
     end
 
     def dirty?

--- a/lib/boxen/cli.rb
+++ b/lib/boxen/cli.rb
@@ -55,7 +55,7 @@ module Boxen
       end
 
       # Return Puppet's exit status.
-      return status.code
+      status.code
     end
   end
 end

--- a/lib/boxen/cli.rb
+++ b/lib/boxen/cli.rb
@@ -1,9 +1,9 @@
-require "boxen/config"
-require "boxen/flags"
-require "boxen/postflight"
-require "boxen/preflight"
-require "boxen/runner"
-require "boxen/util"
+require 'boxen/config'
+require 'boxen/flags'
+require 'boxen/postflight'
+require 'boxen/preflight'
+require 'boxen/runner'
+require 'boxen/util'
 
 module Boxen
   class CLI
@@ -38,24 +38,23 @@ module Boxen
       # overriding anything.
       flags.apply config
 
-      if flags.run?
-        # Run the preflight checks.
-        Boxen::Preflight.run config
+      run_preflight_checks if flags.run?
+      run_postflight_checks if flags.run? && status.success?
 
-        # Save the config for Puppet (and next time).
-        Boxen::Config.save config
-      end
-
-      # Make the magic happen.
-      status = Boxen::CLI.new(config, flags).run
-
-      if flags.run?
-        # Run the postflight checks.
-        Boxen::Postflight.run config if status.success?
-      end
-
-      # Return Puppet's exit status.
       status.code
+    end
+
+    def run_preflight_checks
+      Boxen::Preflight.run config
+      Boxen::Config.save config
+    end
+
+    def run_postflight_checks
+      Boxen::Postflight.run config
+    end
+
+    def status
+      Boxen::CLI.new(config, flags).run
     end
   end
 end

--- a/lib/boxen/config.rb
+++ b/lib/boxen/config.rb
@@ -1,17 +1,16 @@
-require "boxen/keychain"
-require "boxen/project"
-require "fileutils"
-require "json"
-require "octokit"
-require "shellwords"
+require 'boxen/keychain'
+require 'boxen/project'
+require 'fileutils'
+require 'json'
+require 'octokit'
+require 'shellwords'
 
 module Boxen
-
   # All configuration for Boxen, whether it's loaded from command-line
   # args, environment variables, config files, or the keychain.
 
   class Config
-    def self.load(&block)
+    def self.load(&_block)
       new do |config|
         file = "#{config.homedir}/config/boxen/defaults.json"
 
@@ -46,27 +45,27 @@ module Boxen
 
     def self.save(config)
       attrs = {
-        :email        => config.email,
-        :fde          => config.fde?,
-        :homedir      => config.homedir,
-        :login        => config.login,
-        :name         => config.name,
-        :puppetdir    => config.puppetdir,
-        :repodir      => config.repodir,
-        :reponame     => config.reponame,
-        :ghurl        => config.ghurl,
-        :srcdir       => config.srcdir,
-        :user         => config.user,
-        :repotemplate => config.repotemplate,
-        :s3host       => config.s3host,
-        :s3bucket     => config.s3bucket
+        email: config.email,
+        fde: config.fde?,
+        homedir: config.homedir,
+        login: config.login,
+        name: config.name,
+        puppetdir: config.puppetdir,
+        repodir: config.repodir,
+        reponame: config.reponame,
+        ghurl: config.ghurl,
+        srcdir: config.srcdir,
+        user: config.user,
+        repotemplate: config.repotemplate,
+        s3host: config.s3host,
+        s3bucket: config.s3bucket
       }
 
       file = "#{config.homedir}/config/boxen/defaults.json"
       FileUtils.mkdir_p File.dirname file
 
-      File.open file, "wb" do |f|
-        f.write JSON.generate Hash[attrs.reject { |k, v| v.nil? }]
+      File.open file, 'wb' do |f|
+        f.write JSON.generate Hash[attrs.reject { |_k, v| v.nil? }]
       end
 
       keychain          = Boxen::Keychain.new config.user
@@ -77,7 +76,7 @@ module Boxen
 
     # Create a new instance. Yields `self` if `block` is given.
 
-    def initialize(&block)
+    def initialize(&_block)
       @fde  = true
       @pull = true
 
@@ -88,7 +87,7 @@ module Boxen
     # instance is created any time `token` changes.
 
     def api
-      @api ||= Octokit::Client.new :login => token, :password => 'x-oauth-basic'
+      @api ||= Octokit::Client.new login: token, password: 'x-oauth-basic'
     end
 
     # Spew a bunch of debug logging? Default is `false`.
@@ -113,7 +112,7 @@ module Boxen
     # the `BOXEN_NO_FDE` environment variable.
 
     def fde?
-      !ENV["BOXEN_NO_FDE"] && @fde
+      !ENV['BOXEN_NO_FDE'] && @fde
     end
 
     attr_writer :fde
@@ -122,7 +121,7 @@ module Boxen
     # `BOXEN_HOME` environment variable.
 
     def homedir
-      @homedir || ENV["BOXEN_HOME"] || "/opt/boxen"
+      @homedir || ENV['BOXEN_HOME'] || '/opt/boxen'
     end
 
     attr_writer :homedir
@@ -132,7 +131,7 @@ module Boxen
     # overwritten on every run.
 
     def logfile
-      @logfile || ENV["BOXEN_LOG_FILE"] || "#{repodir}/log/boxen.log"
+      @logfile || ENV['BOXEN_LOG_FILE'] || "#{repodir}/log/boxen.log"
     end
 
     attr_writer :logfile
@@ -195,7 +194,7 @@ module Boxen
 
     def projects
       files = Dir["#{repodir}/modules/projects/manifests/*.pp"]
-      names = files.map { |m| File.basename m, ".pp" }.sort
+      names = files.map { |m| File.basename m, '.pp' }.sort
 
       names.map do |name|
         Boxen::Project.new "#{srcdir}/#{name}"
@@ -208,7 +207,7 @@ module Boxen
     # `BOXEN_PUPPET_DIR` environment variable.
 
     def puppetdir
-      @puppetdir || ENV["BOXEN_PUPPET_DIR"] || "/tmp/boxen/puppet"
+      @puppetdir || ENV['BOXEN_PUPPET_DIR'] || '/tmp/boxen/puppet'
     end
 
     attr_writer :puppetdir
@@ -217,7 +216,7 @@ module Boxen
     # `Dir.pwd`. Respects the `BOXEN_REPO_DIR` environment variable.
 
     def repodir
-      @repodir || ENV["BOXEN_REPO_DIR"] || Dir.pwd
+      @repodir || ENV['BOXEN_REPO_DIR'] || Dir.pwd
     end
 
     attr_writer :repodir
@@ -228,7 +227,7 @@ module Boxen
     # Respects the `BOXEN_REPO_NAME` environment variable.
 
     def reponame
-      override = @reponame || ENV["BOXEN_REPO_NAME"]
+      override = @reponame || ENV['BOXEN_REPO_NAME']
       return override unless override.nil?
 
       if File.directory? repodir
@@ -236,9 +235,9 @@ module Boxen
         url = Dir.chdir(repodir) { `git config remote.origin.url`.strip }
 
         # find the path and strip off the .git suffix
-        repo_exp = Regexp.new Regexp.escape(ghuri.host) + "[/:]([^/]+/[^/]+)"
-        if $?.success? && repo_exp.match(url)
-          @reponame = $1.sub /\.git$/, ""
+        repo_exp = Regexp.new Regexp.escape(ghuri.host) + '[/:]([^/]+/[^/]+)'
+        if $CHILD_STATUS.success? && repo_exp.match(url)
+          @reponame = Regexp.last_match(1).sub /\.git$/, ''
         end
       end
     end
@@ -248,7 +247,7 @@ module Boxen
     # GitHub location (public or GitHub Enterprise)
 
     def ghurl
-      @ghurl || ENV["BOXEN_GITHUB_ENTERPRISE_URL"] || "https://github.com"
+      @ghurl || ENV['BOXEN_GITHUB_ENTERPRISE_URL'] || 'https://github.com'
     end
 
     attr_writer :ghurl
@@ -257,7 +256,7 @@ module Boxen
 
     def repotemplate
       default = 'https://github.com/%s'
-      @repotemplate || ENV["BOXEN_REPO_URL_TEMPLATE"] || default
+      @repotemplate || ENV['BOXEN_REPO_URL_TEMPLATE'] || default
     end
 
     attr_writer :repotemplate
@@ -265,14 +264,14 @@ module Boxen
     # Does this Boxen use a GitHub Enterprise instance?
 
     def enterprise?
-      ghurl != "https://github.com"
+      ghurl != 'https://github.com'
     end
 
     # The directory where repos live. Default is
     # `"/Users/#{user}/src"`.
 
     def srcdir
-      @srcdir || ENV["BOXEN_SRC_DIR"] || "/Users/#{user}/src"
+      @srcdir || ENV['BOXEN_SRC_DIR'] || "/Users/#{user}/src"
     end
 
     attr_writer :srcdir
@@ -281,7 +280,7 @@ module Boxen
     # Respects the `BOXEN_NO_ISSUE` environment variable.
 
     def stealth?
-      !!ENV["BOXEN_NO_ISSUE"] || @stealth
+      !!ENV['BOXEN_NO_ISSUE'] || @stealth
     end
 
     attr_writer :stealth
@@ -298,7 +297,7 @@ module Boxen
     # A local user login. Default is the `USER` environment variable.
 
     def user
-      @user || ENV["USER"]
+      @user || ENV['USER']
     end
 
     attr_writer :user
@@ -313,7 +312,7 @@ module Boxen
     # Respects the `BOXEN_S3_HOST` environment variable.
 
     def s3host
-      @s3host || ENV["BOXEN_S3_HOST"] || "s3.amazonaws.com"
+      @s3host || ENV['BOXEN_S3_HOST'] || 's3.amazonaws.com'
     end
 
     attr_writer :s3host
@@ -322,7 +321,7 @@ module Boxen
     # Respects the `BOXEN_S3_BUCKET` environment variable.
 
     def s3bucket
-      @s3bucket || ENV["BOXEN_S3_BUCKET"] || "boxen-downloads"
+      @s3bucket || ENV['BOXEN_S3_BUCKET'] || 'boxen-downloads'
     end
 
     attr_writer :s3bucket

--- a/lib/boxen/flags.rb
+++ b/lib/boxen/flags.rb
@@ -1,5 +1,5 @@
-require "optparse"
-require "boxen/error"
+require 'optparse'
+require 'boxen/error'
 
 module Boxen
   # Various flags and settings parsed from the command line. See
@@ -43,109 +43,109 @@ module Boxen
       @color            = true
 
       @options = OptionParser.new do |o|
-        o.banner = "Usage: #{File.basename $0} [options] [projects...]\n\n"
+        o.banner = "Usage: #{File.basename $PROGRAM_NAME} [options] [projects...]\n\n"
 
-        o.on "--debug", "Be really verbose." do
+        o.on '--debug', 'Be really verbose.' do
           @debug = true
         end
 
-        o.on "--pretend", "--noop", "Don't make changes." do
+        o.on '--pretend', '--noop', "Don't make changes." do
           @pretend = true
         end
 
-        o.on "--report", "Enable puppet reports." do
+        o.on '--report', 'Enable puppet reports.' do
           @report = true
         end
 
-        o.on "--graph", "Enable generation of dependency graphs." do
+        o.on '--graph', 'Enable generation of dependency graphs.' do
           @graph = true
         end
 
-        o.on "--env", "Show useful environment variables." do
+        o.on '--env', 'Show useful environment variables.' do
           @env = true
         end
 
-        o.on "--help", "-h", "-?", "Show help." do
+        o.on '--help', '-h', '-?', 'Show help.' do
           @help = true
         end
 
-        o.on "--disable-service SERVICE", "Disable a Boxen service." do |service|
+        o.on '--disable-service SERVICE', 'Disable a Boxen service.' do |service|
           @disable_service = service
         end
 
-        o.on "--enable-service SERVICE", "Enable a Boxen service." do |service|
+        o.on '--enable-service SERVICE', 'Enable a Boxen service.' do |service|
           @enable_service = service
         end
 
-        o.on "--restart-service SERVICE", "Restart a Boxen service." do |service|
+        o.on '--restart-service SERVICE', 'Restart a Boxen service.' do |service|
           @restart_service = service
         end
 
-        o.on "--disable-services", "Disable all Boxen services." do
+        o.on '--disable-services', 'Disable all Boxen services.' do
           @disable_services = true
         end
 
-        o.on "--enable-services", "Enable all Boxen services." do
+        o.on '--enable-services', 'Enable all Boxen services.' do
           @enable_services = true
         end
 
-        o.on "--restart-services", "Restart all Boxen services." do
+        o.on '--restart-services', 'Restart all Boxen services.' do
           @restart_services = true
         end
 
-        o.on "--list-services", "List Boxen services." do
+        o.on '--list-services', 'List Boxen services.' do
           @list_services = true
         end
 
-        o.on "--homedir DIR", "Boxen's home directory." do |homedir|
+        o.on '--homedir DIR', "Boxen's home directory." do |homedir|
           @homedir = homedir
         end
 
-        o.on "--logfile DIR", "Boxen's log file." do |logfile|
+        o.on '--logfile DIR', "Boxen's log file." do |logfile|
           @logfile = logfile
         end
 
-        o.on "--login LOGIN", "Your GitHub login." do |login|
+        o.on '--login LOGIN', 'Your GitHub login.' do |login|
           @login = login
         end
 
-        o.on "--no-fde", "Don't require full disk encryption." do
+        o.on '--no-fde', "Don't require full disk encryption." do
           @fde = false
         end
 
         # --no-pull is used before options are parsed, but consumed here.
 
-        o.on "--no-pull", "Don't try to update code before applying."
+        o.on '--no-pull', "Don't try to update code before applying."
 
-        o.on "--no-issue", "--stealth", "Don't open an issue on failure." do
+        o.on '--no-issue', '--stealth', "Don't open an issue on failure." do
           @stealth = true
         end
 
-        o.on "--token TOKEN", "Your GitHub OAuth token." do |token|
+        o.on '--token TOKEN', 'Your GitHub OAuth token.' do |token|
           @token = token
         end
 
-        o.on "--profile", "Profile the Puppet run." do
+        o.on '--profile', 'Profile the Puppet run.' do
           @profile = true
         end
 
-        o.on "--future-parser", "Enable the Puppet future parser" do
+        o.on '--future-parser', 'Enable the Puppet future parser' do
           @future_parser = true
         end
 
-        o.on "--projects", "Show available projects." do
+        o.on '--projects', 'Show available projects.' do
           @projects = true
         end
 
-        o.on "--srcdir DIR", "The directory where repos live." do |srcdir|
+        o.on '--srcdir DIR', 'The directory where repos live.' do |srcdir|
           @srcdir = srcdir
         end
 
-        o.on "--user USER", "Your local user." do |user|
+        o.on '--user USER', 'Your local user.' do |user|
           @user = user
         end
 
-        o.on "--no-color", "Disable colors." do
+        o.on '--no-color', 'Disable colors.' do
           @color = false
         end
       end
@@ -233,7 +233,7 @@ module Boxen
       self
 
     rescue OptionParser::MissingArgument, OptionParser::InvalidOption => e
-      raise Boxen::Error, "#{e.message}\n#@options"
+      raise Boxen::Error, "#{e.message}\n#{@options}"
     end
 
     def pretend?

--- a/lib/boxen/flags.rb
+++ b/lib/boxen/flags.rb
@@ -2,12 +2,10 @@ require "optparse"
 require "boxen/error"
 
 module Boxen
-
   # Various flags and settings parsed from the command line. See
   # Setup::Configuration for more info.
 
   class Flags
-
     attr_reader :args
     attr_reader :homedir
     attr_reader :logfile

--- a/lib/boxen/hook.rb
+++ b/lib/boxen/hook.rb
@@ -43,5 +43,5 @@ module Boxen
   end
 end
 
-require "boxen/hook/github_issue"
-require "boxen/hook/web"
+require 'boxen/hook/github_issue'
+require 'boxen/hook/web'

--- a/lib/boxen/hook/github_issue.rb
+++ b/lib/boxen/hook/github_issue.rb
@@ -1,13 +1,13 @@
-require "boxen/hook"
+require 'boxen/hook'
 
 module Boxen
   class Hook
     class GitHubIssue < Hook
       def perform?
         enabled? &&
-        !config.stealth? && !config.pretend? &&
-        !config.login.to_s.empty? &&
-        checkout.master?
+          !config.stealth? && !config.pretend? &&
+          !config.login.to_s.empty? &&
+          checkout.master?
       end
 
       def call
@@ -33,7 +33,7 @@ module Boxen
       end
 
       def shell
-        ENV["SHELL"]
+        ENV['SHELL']
       end
 
       def log
@@ -45,7 +45,7 @@ module Boxen
 
         title = "Failed for #{config.user}"
         config.api.create_issue(config.reponame, title, failure_details,
-          :labels => [failure_label])
+                                labels: [failure_label])
       end
 
       def close_failures
@@ -61,9 +61,12 @@ module Boxen
       def failures
         return [] unless issues?
 
-        issues = config.api.list_issues(config.reponame, :state => 'open',
-          :labels => failure_label, :creator => config.login)
-        issues.reject! {|i| i.labels.collect(&:name).include?(ongoing_label)}
+        issues = config.api.list_issues(
+          config.reponame,
+          state: 'open',
+          labels: failure_label, creator: config.login
+        )
+        issues.reject! { |i| i.labels.collect(&:name).include?(ongoing_label) }
         issues
       end
 
@@ -74,13 +77,13 @@ module Boxen
         body << "\n\n"
 
         if checkout.dirty?
-          body << "### Changes"
+          body << '### Changes'
           body << "\n\n"
           body << "```\n#{checkout.changes}\n```"
           body << "\n\n"
         end
 
-        body << "### Puppet Command"
+        body << '### Puppet Command'
         body << "\n\n"
         body << "```\n#{puppet.command.join(' ')}\n```"
         body << "\n\n"
@@ -110,6 +113,7 @@ module Boxen
       end
 
       private
+
       def required_environment_variables
         ['BOXEN_ISSUES_ENABLED']
       end

--- a/lib/boxen/hook/web.rb
+++ b/lib/boxen/hook/web.rb
@@ -1,6 +1,6 @@
-require "boxen/hook"
-require "json"
-require "net/http"
+require 'boxen/hook'
+require 'json'
+require 'net/http'
 
 module Boxen
   class Hook
@@ -10,12 +10,13 @@ module Boxen
       end
 
       private
+
       def call
         payload = {
-          :login  => config.user,
-          :sha    => checkout.sha,
-          :status => result.success? ? 'success' : 'failure',
-          :time   => "#{Time.now.utc.to_i}"
+          login: config.user,
+          sha: checkout.sha,
+          status: result.success? ? 'success' : 'failure',
+          time: "#{Time.now.utc.to_i}"
         }
 
         post_web_hook payload

--- a/lib/boxen/keychain.rb
+++ b/lib/boxen/keychain.rb
@@ -1,25 +1,24 @@
-require "shellwords"
+require 'shellwords'
 
 module Boxen
   class Keychain
-
     # The keychain proxy we use to provide isolation and a friendly
     # message in security prompts.
 
-    HELPER = File.expand_path "../../../script/Boxen", __FILE__
+    HELPER = File.expand_path '../../../script/Boxen', __FILE__
 
     # The service name to use when loading/saving passwords.
 
-    PASSWORD_SERVICE = "GitHub Password"
+    PASSWORD_SERVICE = 'GitHub Password'
 
     # The service name to use when loading/saving API keys.
 
-    TOKEN_SERVICE = "GitHub API Token"
+    TOKEN_SERVICE = 'GitHub API Token'
 
     def initialize(login)
       @login = login
       # Clear the password. We're storing tokens now.
-      set PASSWORD_SERVICE, ""
+      set PASSWORD_SERVICE, ''
     end
 
     def token
@@ -38,21 +37,21 @@ module Boxen
       cmd = shellescape(HELPER, service, login)
 
       result = `#{cmd}`.strip
-      $?.success? ? result : nil
+      $CHILD_STATUS.success? ? result : nil
     end
 
     def set(service, token)
       cmd = shellescape(HELPER, service, login, token)
 
       unless system *cmd
-        raise Boxen::Error, "Can't save #{service} in the keychain."
+        fail Boxen::Error, "Can't save #{service} in the keychain."
       end
 
       token
     end
 
     def shellescape(*args)
-      args.map { |s| Shellwords.shellescape s }.join " "
+      args.map { |s| Shellwords.shellescape s }.join ' '
     end
   end
 end

--- a/lib/boxen/postflight.rb
+++ b/lib/boxen/postflight.rb
@@ -1,13 +1,11 @@
-require "boxen/check"
+require 'boxen/check'
 
 module Boxen
-
   # The superclass for postflight checks.
 
   class Postflight < Boxen::Check
-
     # Load all available postflight checks.
 
-    register File.expand_path("../postflight", __FILE__)
+    register File.expand_path('../postflight', __FILE__)
   end
 end

--- a/lib/boxen/postflight/active.rb
+++ b/lib/boxen/postflight/active.rb
@@ -1,5 +1,5 @@
-require "boxen/postflight"
-require "boxen/util"
+require 'boxen/postflight'
+require 'boxen/util'
 
 # Checks to see if the basic environment is loaded.
 
@@ -10,7 +10,7 @@ class Boxen::Postflight::Active < Boxen::Postflight
 
   def run
     warn "You haven't loaded Boxen's environment yet!",
-      "To permanently fix this, source #{config.envfile} at the end",
-      "of your shell's startup file."
+         "To permanently fix this, source #{config.envfile} at the end",
+         "of your shell's startup file."
   end
 end

--- a/lib/boxen/postflight/env.rb
+++ b/lib/boxen/postflight/env.rb
@@ -1,15 +1,13 @@
-require "boxen/postflight"
+require 'boxen/postflight'
 
 class Boxen::Postflight::Env < Boxen::Postflight
-
   # Calculate an MD5 checksum for the current environment.
 
   def self.checksum
-
     # We can't get this from config 'cause it's static (gotta happen
     # on load), and BOXEN_HOME might not be set.
 
-    home = ENV["BOXEN_HOME"] || "/opt/boxen"
+    home = ENV['BOXEN_HOME'] || '/opt/boxen'
     return unless File.file? "#{home}/env.sh"
 
     `find #{home}/env* -type f 2>&1 | sort | xargs /sbin/md5 | /sbin/md5 -q`.strip
@@ -17,7 +15,7 @@ class Boxen::Postflight::Env < Boxen::Postflight
 
   # The checksum when this file was loaded.
 
-  CHECKSUM = self.checksum
+  CHECKSUM = checksum
 
   def ok?
     self.class.checksum == CHECKSUM

--- a/lib/boxen/preflight.rb
+++ b/lib/boxen/preflight.rb
@@ -1,13 +1,11 @@
-require "boxen/check"
+require 'boxen/check'
 
 module Boxen
-
   # The superclass for preflight checks.
 
   class Preflight < Boxen::Check
-
     # Load all available preflight checks.
 
-    register File.expand_path("../preflight", __FILE__)
+    register File.expand_path('../preflight', __FILE__)
   end
 end

--- a/lib/boxen/preflight/creds.rb
+++ b/lib/boxen/preflight/creds.rb
@@ -1,6 +1,6 @@
-require "boxen/preflight"
-require "highline"
-require "octokit"
+require 'boxen/preflight'
+require 'highline'
+require 'octokit'
 
 # HACK: Unless this is `false`, HighLine has some really bizarre
 # problems with empty/expended streams at bizarre intervals.
@@ -8,8 +8,8 @@ require "octokit"
 HighLine.track_eof = false
 
 class Boxen::Preflight::Creds < Boxen::Preflight
-  attr :otp
-  attr :password
+  attr_reader :otp
+  attr_reader :password
 
   def ok?
     if config.token && config.api.user
@@ -23,11 +23,11 @@ class Boxen::Preflight::Creds < Boxen::Preflight
   end
 
   def tmp_api
-    @tmp_api ||= Octokit::Client.new :login => config.login, :password => password, :auto_paginate => true
+    @tmp_api ||= Octokit::Client.new login: config.login, password: password, auto_paginate: true
   end
 
   def headers
-    otp.nil? ? {} : {"X-GitHub-OTP" => otp}
+    otp.nil? ? {} : { 'X-GitHub-OTP' => otp }
   end
 
   def get_otp
@@ -36,7 +36,7 @@ class Boxen::Preflight::Creds < Boxen::Preflight
     # junk API call to send OTP until we implement PUT
     tmp_api.create_authorization rescue nil
 
-    @otp = console.ask "One time password (via SMS or device):" do |q|
+    @otp = console.ask 'One time password (via SMS or device):' do |q|
       q.echo = '*'
     end
   end
@@ -47,40 +47,38 @@ class Boxen::Preflight::Creds < Boxen::Preflight
   #
   # Returns a list of authorizations
   def get_tokens
-    begin
-      tmp_api.authorizations(:headers => headers)
-    rescue Octokit::Unauthorized
-      abort "Sorry, I can't auth you on GitHub.",
-        "Please check your credentials and teams and give it another try."
-    rescue Octokit::OneTimePasswordRequired
-      puts
-      if otp.nil?
-        warn "It looks like you have two-factor auth enabled."
-      else
-        warn "That one time password didn't work. Let's try again."
-      end
-      get_otp
-      get_tokens
+    tmp_api.authorizations(headers: headers)
+  rescue Octokit::Unauthorized
+    abort "Sorry, I can't auth you on GitHub.",
+          'Please check your credentials and teams and give it another try.'
+  rescue Octokit::OneTimePasswordRequired
+    puts
+    if otp.nil?
+      warn 'It looks like you have two-factor auth enabled.'
+    else
+      warn "That one time password didn't work. Let's try again."
     end
+    get_otp
+    get_tokens
   end
 
   def run
     fetch_login_and_password
     tokens = get_tokens
 
-    unless auth = tokens.detect { |a| a.note == "Boxen" }
+    unless auth = tokens.detect { |a| a.note == 'Boxen' }
       auth = tmp_api.create_authorization \
-        :note => "Boxen",
-        :scopes => %w(repo user),
-        :headers => headers
+        note: 'Boxen',
+        scopes: %w(repo user),
+        headers: headers
     end
 
     config.token = auth.token
 
     unless ok?
       puts
-      abort "Something went terribly wrong.",
-        "I was able to get your OAuth token, but was unable to use it."
+      abort 'Something went terribly wrong.',
+            'I was able to get your OAuth token, but was unable to use it.'
     end
   end
 
@@ -89,13 +87,13 @@ class Boxen::Preflight::Creds < Boxen::Preflight
   def fetch_login_and_password
     console = HighLine.new
 
-    config.login = fetch_from_env("login") || console.ask("GitHub login: ") do |q|
+    config.login = fetch_from_env('login') || console.ask('GitHub login: ') do |q|
       q.default = config.login || config.user
       q.validate = /\A[^@]+\Z/
     end
 
-    @password = fetch_from_env("password") || console.ask("GitHub password: ") do |q|
-      q.echo = "*"
+    @password = fetch_from_env('password') || console.ask('GitHub password: ') do |q|
+      q.echo = '*'
     end
   end
 

--- a/lib/boxen/preflight/directories.rb
+++ b/lib/boxen/preflight/directories.rb
@@ -1,5 +1,5 @@
-require "boxen/preflight"
-require "boxen/util"
+require 'boxen/preflight'
+require 'boxen/util'
 
 class Boxen::Preflight::Directories < Boxen::Preflight
   def ok?
@@ -9,11 +9,12 @@ class Boxen::Preflight::Directories < Boxen::Preflight
   end
 
   def run
-    Boxen::Util.sudo("/bin/mkdir", "-p", config.homedir) &&
-      Boxen::Util.sudo("/usr/sbin/chown", "#{config.user}:staff", config.homedir)
+    Boxen::Util.sudo('/bin/mkdir', '-p', config.homedir) &&
+      Boxen::Util.sudo('/usr/sbin/chown', "#{config.user}:staff", config.homedir)
   end
 
   private
+
   def homedir_directory_exists?
     File.directory?(config.homedir)
   end

--- a/lib/boxen/preflight/etc_my_cnf.rb
+++ b/lib/boxen/preflight/etc_my_cnf.rb
@@ -1,12 +1,12 @@
-require "boxen/preflight"
+require 'boxen/preflight'
 
 class Boxen::Preflight::EtcMyCnf < Boxen::Preflight
   def run
-    abort "You have an /etc/my.cnf file.",
-      "This will confuse Boxen's MySQL a lot. Please remove it."
+    abort 'You have an /etc/my.cnf file.',
+          "This will confuse Boxen's MySQL a lot. Please remove it."
   end
 
   def ok?
-    !File.file? "/etc/my.cnf"
+    !File.file? '/etc/my.cnf'
   end
 end

--- a/lib/boxen/preflight/identity.rb
+++ b/lib/boxen/preflight/identity.rb
@@ -1,4 +1,4 @@
-require "boxen/preflight"
+require 'boxen/preflight'
 
 class Boxen::Preflight::Identity < Boxen::Preflight
   def ok?

--- a/lib/boxen/preflight/os.rb
+++ b/lib/boxen/preflight/os.rb
@@ -1,4 +1,4 @@
-require "boxen/preflight"
+require 'boxen/preflight'
 
 class Boxen::Preflight::OS < Boxen::Preflight
   SUPPORTED_RELEASES = %w(10.8 10.9 10.10)
@@ -14,7 +14,7 @@ class Boxen::Preflight::OS < Boxen::Preflight
   private
 
   def osx?
-    `uname -s`.chomp == "Darwin"
+    `uname -s`.chomp == 'Darwin'
   end
 
   def supported_release?

--- a/lib/boxen/preflight/rbenv.rb
+++ b/lib/boxen/preflight/rbenv.rb
@@ -1,9 +1,9 @@
-require "boxen/preflight"
+require 'boxen/preflight'
 
 class Boxen::Preflight::Rbenv < Boxen::Preflight
   def run
-    warn "You have an existing rbenv installed in ~/.rbenv.",
-      "Boxen provides its own rbenv, so consider deleting yours."
+    warn 'You have an existing rbenv installed in ~/.rbenv.',
+         'Boxen provides its own rbenv, so consider deleting yours.'
   end
 
   def ok?

--- a/lib/boxen/preflight/rvm.rb
+++ b/lib/boxen/preflight/rvm.rb
@@ -1,9 +1,9 @@
-require "boxen/preflight"
+require 'boxen/preflight'
 
 class Boxen::Preflight::RVM < Boxen::Preflight
   def run
-    abort "You have an rvm installed in ~/.rvm.",
-      "Boxen uses rbenv to install ruby, so please `rvm implode`"
+    abort 'You have an rvm installed in ~/.rvm.',
+          'Boxen uses rbenv to install ruby, so please `rvm implode`'
   end
 
   def ok?

--- a/lib/boxen/project.rb
+++ b/lib/boxen/project.rb
@@ -1,9 +1,7 @@
 module Boxen
-
   # A project managed by Boxen.
 
   class Project
-
     # The directory where this project's repo should live.
 
     attr_reader :dir

--- a/lib/boxen/puppeteer.rb
+++ b/lib/boxen/puppeteer.rb
@@ -2,15 +2,13 @@ require "fileutils"
 require "boxen/util"
 
 module Boxen
-
   # Manages an invocation of puppet.
 
   class Puppeteer
-
     class Status < Struct.new(:code)
       # Puppet's detailed exit codes reserves 2 for a successful run with changes
       def success?
-        [0,2].include?(code)
+        [0, 2].include?(code)
       end
     end
 

--- a/lib/boxen/puppeteer.rb
+++ b/lib/boxen/puppeteer.rb
@@ -1,5 +1,5 @@
-require "fileutils"
-require "boxen/util"
+require 'fileutils'
+require 'boxen/util'
 
 module Boxen
   # Manages an invocation of puppet.
@@ -22,59 +22,59 @@ module Boxen
       manifestdir = "#{config.repodir}/manifests"
       puppet      = "#{config.repodir}/bin/puppet"
 
-      [puppet, "apply", flags, manifestdir].flatten
+      [puppet, 'apply', flags, manifestdir].flatten
     end
 
     def hiera_config
       if File.exist? "#{config.repodir}/config/hiera.yaml"
         "#{config.repodir}/config/hiera.yaml"
       else
-        "/dev/null"
+        '/dev/null'
       end
     end
 
     def flags
       flags = []
-      root  = File.expand_path "../../..", __FILE__
+      root  = File.expand_path '../../..', __FILE__
 
-      flags << ["--group",       "admin"]
-      flags << ["--confdir",     "#{config.puppetdir}/conf"]
-      flags << ["--vardir",      "#{config.puppetdir}/var"]
-      flags << ["--libdir",      "#{config.repodir}/lib"]#:#{root}/lib"]
-      flags << ["--libdir",      "#{root}/lib"]
-      flags << ["--modulepath",  "#{config.repodir}/modules:#{config.repodir}/shared"]
+      flags << ['--group',       'admin']
+      flags << ['--confdir',     "#{config.puppetdir}/conf"]
+      flags << ['--vardir',      "#{config.puppetdir}/var"]
+      flags << ['--libdir',      "#{config.repodir}/lib"] #:#{root}/lib"]
+      flags << ['--libdir',      "#{root}/lib"]
+      flags << ['--modulepath',  "#{config.repodir}/modules:#{config.repodir}/shared"]
 
       # Don't ever complain about Hiera to me
-      flags << ["--hiera_config", hiera_config]
+      flags << ['--hiera_config', hiera_config]
 
       # Log to both the console and a file.
 
-      flags << ["--logdest", config.logfile]
-      flags << ["--logdest", "console"]
+      flags << ['--logdest', config.logfile]
+      flags << ['--logdest', 'console']
 
       # For some reason Puppet tries to set up a bunch of rrd stuff
       # (user, group) unless reports are completely disabled.
 
-      flags << "--no-report" unless config.report?
-      flags << "--detailed-exitcodes"
+      flags << '--no-report' unless config.report?
+      flags << '--detailed-exitcodes'
 
-      flags << "--graph" if config.graph?
+      flags << '--graph' if config.graph?
 
-      flags << "--show_diff"
+      flags << '--show_diff'
 
       if config.profile?
-        flags << "--evaltrace"
-        flags << "--summarize"
+        flags << '--evaltrace'
+        flags << '--summarize'
       end
 
       if config.future_parser?
-        flags << "--parser=future"
+        flags << '--parser=future'
       end
 
-      flags << "--debug" if config.debug?
-      flags << "--noop"  if config.pretend?
+      flags << '--debug' if config.debug?
+      flags << '--noop'  if config.pretend?
 
-      flags << "--color=false" unless config.color?
+      flags << '--color=false' unless config.color?
 
       flags.flatten
     end
@@ -91,29 +91,29 @@ module Boxen
       FileUtils.mkdir_p File.dirname config.logfile
       FileUtils.touch config.logfile
 
-      if File.file? "Puppetfile"
+      if File.file? 'Puppetfile'
         librarian = "#{config.repodir}/bin/librarian-puppet"
 
         unless config.enterprise?
           # Set an environment variable for librarian-puppet's
           # github_tarball source strategy.
-          ENV["GITHUB_API_TOKEN"] = config.token
+          ENV['GITHUB_API_TOKEN'] = config.token
         end
 
-        librarian_command = [librarian, "install", "--path=#{config.repodir}/shared"]
-        librarian_command << "--verbose" if config.debug?
+        librarian_command = [librarian, 'install', "--path=#{config.repodir}/shared"]
+        librarian_command << '--verbose' if config.debug?
 
-        warn librarian_command.join(" ") if config.debug?
+        warn librarian_command.join(' ') if config.debug?
         unless system *librarian_command
           abort "Can't run Puppet, fetching dependencies with librarian failed."
         end
       end
 
-      warn command.join(" ") if config.debug?
+      warn command.join(' ') if config.debug?
 
       Boxen::Util.sudo *command
 
-      Status.new($?.exitstatus)
+      Status.new($CHILD_STATUS.exitstatus)
     end
   end
 end

--- a/lib/boxen/runner.rb
+++ b/lib/boxen/runner.rb
@@ -1,11 +1,11 @@
-require "boxen/checkout"
-require "boxen/config"
-require "boxen/hook"
-require "boxen/flags"
-require "boxen/puppeteer"
-require "boxen/service"
-require "boxen/util"
-require "facter"
+require 'boxen/checkout'
+require 'boxen/config'
+require 'boxen/hook'
+require 'boxen/flags'
+require 'boxen/puppeteer'
+require 'boxen/service'
+require 'boxen/util'
+require 'facter'
 
 module Boxen
   class Runner
@@ -26,7 +26,7 @@ module Boxen
     def process
       # --env prints out the current BOXEN_ env vars.
 
-      exec "env | grep ^BOXEN_ | sort" if flags.env?
+      exec 'env | grep ^BOXEN_ | sort' if flags.env?
 
       process_flags
 
@@ -51,7 +51,7 @@ module Boxen
       # --projects prints a list of available projects and exits.
 
       if flags.projects?
-        puts "You can install any of these projects with `#{$0} <project-name>`:\n"
+        puts "You can install any of these projects with `#{$PROGRAM_NAME} <project-name>`:\n"
 
         config.projects.each do |project|
           puts "  #{project.name}"
@@ -138,7 +138,7 @@ module Boxen
 
     def process_args
       projects = flags.args.join(',')
-      File.open("#{config.repodir}/.projects", "w+") do |f|
+      File.open("#{config.repodir}/.projects", 'w+') do |f|
         f.truncate 0
         f.write projects
       end

--- a/lib/boxen/runner.rb
+++ b/lib/boxen/runner.rb
@@ -48,7 +48,6 @@ module Boxen
     end
 
     def process_flags
-
       # --projects prints a list of available projects and exits.
 
       if flags.projects?
@@ -135,7 +134,6 @@ module Boxen
 
         exit
       end
-
     end
 
     def process_args

--- a/lib/boxen/service.rb
+++ b/lib/boxen/service.rb
@@ -1,4 +1,4 @@
-require "boxen/util"
+require 'boxen/util'
 
 module Boxen
   class Service
@@ -44,7 +44,7 @@ module Boxen
     end
 
     def self.location
-      "/Library/LaunchDaemons"
+      '/Library/LaunchDaemons'
     end
 
     def self.files

--- a/lib/boxen/util.rb
+++ b/lib/boxen/util.rb
@@ -1,14 +1,8 @@
 module Boxen
   module Util
-
-    # Is Boxen active?
-
     def self.active?
       ENV.include? "BOXEN_HOME"
     end
-
-
-    # Run `args` as a system command with sudo if necessary.
 
     def self.sudo *args
       system "sudo", "-p", "Password for sudo: ", *args

--- a/lib/boxen/util.rb
+++ b/lib/boxen/util.rb
@@ -1,11 +1,11 @@
 module Boxen
   module Util
     def self.active?
-      ENV.include? "BOXEN_HOME"
+      ENV.include? 'BOXEN_HOME'
     end
 
-    def self.sudo *args
-      system "sudo", "-p", "Password for sudo: ", *args
+    def self.sudo(*args)
+      system 'sudo', '-p', 'Password for sudo: ', *args
     end
   end
 end

--- a/lib/facter/boxen.rb
+++ b/lib/facter/boxen.rb
@@ -1,5 +1,5 @@
-require "json"
-require "boxen/config"
+require 'json'
+require 'boxen/config'
 
 config      = Boxen::Config.load
 facts       = {}
@@ -7,16 +7,16 @@ factsdir    = "#{config.homedir}/config/facts"
 dot_boxen   = "#{ENV['HOME']}/.boxen"
 user_config = "#{dot_boxen}/config.json"
 
-facts["github_login"]  = config.login
-facts["github_email"]  = config.email
-facts["github_name"]   = config.name
-facts["github_token"]  = config.token
+facts['github_login']  = config.login
+facts['github_email']  = config.email
+facts['github_name']   = config.name
+facts['github_token']  = config.token
 
-facts["boxen_home"]    = config.homedir
-facts["boxen_srcdir"]  = config.srcdir
-facts["boxen_repodir"] = config.repodir
-facts["boxen_user"]    = config.user
-facts["luser"]         = config.user # this is goin' away
+facts['boxen_home']    = config.homedir
+facts['boxen_srcdir']  = config.srcdir
+facts['boxen_repodir'] = config.repodir
+facts['boxen_user']    = config.user
+facts['luser']         = config.user # this is goin' away
 
 Dir["#{config.homedir}/config/facts/*.json"].each do |file|
   facts.merge! JSON.parse File.read file

--- a/lib/system_timer.rb
+++ b/lib/system_timer.rb
@@ -6,8 +6,7 @@
 # To squash the message and stop confusing people, this shim just
 # exposes Timeout as SystemTimer. I'm a bad person.
 
-
-if (!defined?(RUBY_ENGINE) || "ruby" == RUBY_ENGINE) && RUBY_VERSION < '1.9'
-  require "timeout"
+if (!defined?(RUBY_ENGINE) || 'ruby' == RUBY_ENGINE) && RUBY_VERSION < '1.9'
+  require 'timeout'
   SystemTimer = Timeout
 end

--- a/test/boxen_flags_test.rb
+++ b/test/boxen_flags_test.rb
@@ -212,6 +212,6 @@ class BoxenFlagsTest < Boxen::Test
   # Create an instance of Boxen::Flags with optional `args`.
 
   def flags(*args)
-    Boxen::Flags.new *args
+    Boxen::Flags.new(*args)
   end
 end

--- a/test/boxen_puppeteer_test.rb
+++ b/test/boxen_puppeteer_test.rb
@@ -80,7 +80,7 @@ class BoxenPuppeteerTest < Boxen::Test
   def assert_flag_value(flag, value, flags)
     pair = [flag, value]
 
-    found = (0..flags.size).detect do |i|
+    found = (0..flags.size).find do |i|
       candidate = flags[i, pair.size]
       value == :anything ? candidate.size == pair.size : candidate == pair
     end

--- a/test/boxen_util_test.rb
+++ b/test/boxen_util_test.rb
@@ -13,8 +13,9 @@ class BoxenUtilTest < Boxen::Test
   end
 
   def test_self_sudo
-    Boxen::Util.expects(:system).
-      with "sudo", "-p", "Password for sudo: ", "echo", "foo"
+    Boxen::Util.expects(:system).with(
+      "sudo", "-p", "Password for sudo: ", "echo", "foo"
+    )
 
     Boxen::Util.sudo "echo", "foo"
   end


### PR DESCRIPTION
- Remove unneeded newlines
- Use Ruby 1.9 Hash syntax
- Single-quote non-interpolated strings
- Expand long method chains into multiple lines
- Remove unnecessary references to 'self'
- Use English global variable names
- Refactor long lines/methods into smaller methods