### PR TITLE
add support for new GitHub authorizations API using fingerprint

### DIFF
--- a/boxen.gemspec
+++ b/boxen.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "ansi",             "~> 1.4"
   gem.add_dependency "hiera",            "~> 1.0"
-  gem.add_dependency "highline",         "~> 1.6"
+  gem.add_dependency "highline",         "~> 1.6.0"
   gem.add_dependency "json_pure",        [">= 1.7.7", "< 2.0"]
   gem.add_dependency "librarian-puppet", "~> 1.0.0"
   gem.add_dependency "octokit",          "~> 2.7", ">= 2.7.1"

--- a/lib/boxen/preflight/creds.rb
+++ b/lib/boxen/preflight/creds.rb
@@ -133,7 +133,7 @@ class Boxen::Preflight::Creds < Boxen::Preflight
       if serial_number_match_data
         # The fingerprint must be unique across all personal access tokens for a
         # given user. We prefix the serial number with the application name to
-        # differeniate between any other personal access token that uses the
+        # differentiate between any other personal access token that uses the
         # Mac serial number for the fingerprint.
         Digest::SHA256.hexdigest("Boxen: #{serial_number_match_data[1]}")
       else

--- a/test/boxen_preflight_creds_test.rb
+++ b/test/boxen_preflight_creds_test.rb
@@ -81,7 +81,7 @@ class BoxenPreflightCredsTest < Boxen::Test
     assert_equal "p", preflight.instance_variable_get(:@password)
   end
 
-  def test_basic_with_existing_token
+  def test_run_with_existing_token
     preflight = Boxen::Preflight::Creds.new @config
     note = "App1"
     fingerprint = "Fingerprint1"
@@ -103,7 +103,7 @@ class BoxenPreflightCredsTest < Boxen::Test
     preflight.run
   end
 
-  def test_basic_with_no_existing_token
+  def test_run_with_no_existing_token
     preflight = Boxen::Preflight::Creds.new @config
     note = "App1"
     fingerprint = "Fingerprint1"
@@ -125,7 +125,7 @@ class BoxenPreflightCredsTest < Boxen::Test
     preflight.run
   end
 
-  def test_basic_does_not_delete_unrelated_tokens
+  def test_run_does_not_delete_unrelated_tokens
     preflight = Boxen::Preflight::Creds.new @config
     note = "App1"
     fingerprint = "Fingerprint1"
@@ -151,7 +151,7 @@ class BoxenPreflightCredsTest < Boxen::Test
     preflight.run
   end
 
-  def test_basic_does_delete_legacy_token
+  def test_run_does_delete_legacy_token
     preflight = Boxen::Preflight::Creds.new @config
     note = "App1"
     fingerprint = "Fingerprint1"


### PR DESCRIPTION
This PR attempts to fix the issues discussed in https://github.com/boxen/boxen/issues/182. The general approach is:

* Detect if there is any existing authorization that has the same description and fingerprint.
* If there is a match we delete the existing authorization, as we can't retrieve its plaintext token value.
* Create a new authorization using the `SHA256` of the user's machine as the fingerprint and the user's hostname as part of the description (to help users manage tokens in the GitHub UI).

This PR currently takes no steps to delete existing tokens that do not yet have a fingerprint (i.e. all existing tokens in use). Right now a user may have the same token on multiple installs of boxen. So, if we add logic to delete the single existing token it will invalidate it on all the user's other installs. This probably isn't a big deal, as it should simply ask them to auth again. But. I thought I'd double check that assumption with you all before adding the deletion logic. 

fixes #182

/cc @mastahyeti @gregose @jasonrudolph @pengwynn @mikemcquaid 