### PR TITLE
Users can skip operating system check

### DIFF
--- a/boxen.gemspec
+++ b/boxen.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "boxen"
-  gem.version       = "2.7.1"
+  gem.version       = "2.7.2"
   gem.authors       = ["John Barnette", "Will Farrington", "David Goodlad"]
   gem.email         = ["jbarnette@github.com", "wfarr@github.com", "dgoodlad@github.com"]
   gem.description   = "Manage Mac development boxes with love (and Puppet)."

--- a/lib/boxen/preflight/os.rb
+++ b/lib/boxen/preflight/os.rb
@@ -4,7 +4,7 @@ class Boxen::Preflight::OS < Boxen::Preflight
   SUPPORTED_RELEASES = %w(10.8 10.9 10.10)
 
   def ok?
-    osx? && supported_release?
+    osx? && (skip_os_check? || supported_release?)
   end
 
   def run
@@ -25,5 +25,9 @@ class Boxen::Preflight::OS < Boxen::Preflight
 
   def current_release
     @current_release ||= `sw_vers -productVersion`
+  end
+  
+  def skip_os_check?
+    ENV['SKIP_OS_CHECK'] == '1'
   end
 end


### PR DESCRIPTION
Allow users to skip the OS X version check if they choose to fend off the dragons.