### PR TITLE
Allow symlink from ~/.rbenv to boxen rbenv

### DIFF
--- a/lib/boxen/preflight/rbenv.rb
+++ b/lib/boxen/preflight/rbenv.rb
@@ -7,6 +7,9 @@ class Boxen::Preflight::Rbenv < Boxen::Preflight
   end
 
   def ok?
-    !File.exist? "#{ENV['HOME']}/.rbenv"
+    rbenv_location = "#{ENV['HOME']}/.rbenv"
+    !File.exist?(rbenv_location) ||
+         (File.symlink?(rbenv_location) &&
+          File.readlink(rbenv_location) == "/opt/rubies/")
   end
 end


### PR DESCRIPTION
- Some libs/apps only support looking for rbenv at ~/.rbenv
- Boxen should not complain if ~/.rbenv is simply pointing to the boxe
  rbenv