### PR TITLE
fix IOPlatformSerialNumber regex to match serial from VM.

### DIFF
--- a/lib/boxen/preflight/creds.rb
+++ b/lib/boxen/preflight/creds.rb
@@ -129,7 +129,7 @@ class Boxen::Preflight::Creds < Boxen::Preflight
       # Computer."
       serial_number_match_data = IO.popen(
         ["ioreg", "-c", "IOPlatformExpertDevice", "-d", "2"]
-      ).read.match(/"IOPlatformSerialNumber" = "([[:alnum:]]+)"/)
+      ).read.match(/"IOPlatformSerialNumber" = "([[:alnum:]\/]+)"/)
       if serial_number_match_data
         # The fingerprint must be unique across all personal access tokens for a
         # given user. We prefix the serial number with the application name to


### PR DESCRIPTION
it's related with https://github.com/boxen/our-boxen/issues/766

On virtual machine(at least VMWare Fusion), serial number contains '/' character as shown below screenshot.

<img width="879" alt="screen shot 2015-12-07 at 10 15 05" src="https://cloud.githubusercontent.com/assets/854492/11782660/9a99592e-a2b5-11e5-81d4-eca20084c41a.png">
