### PR TITLE
Bump to 2.9.0 and update author list

### DIFF
--- a/boxen.gemspec
+++ b/boxen.gemspec
@@ -3,8 +3,11 @@
 Gem::Specification.new do |gem|
   gem.name          = "boxen"
   gem.version       = "2.9.0"
-  gem.authors       = ["John Barnette", "Will Farrington", "David Goodlad", "Jacob Bednarz"]
-  gem.email         = ["jbarnette@github.com", "wfarr@github.com", "dgoodlad@github.com", "jacob.bednarz@gmail.com"]
+  # Thanks go out to the previous maintainers John Barnette, Will
+  # Farrington, David Goodlad and Mike McQuaid for getting this project
+  # to where it is today.
+  gem.authors       = ["Jacob Bednarz"]
+  gem.email         = ["jacob.bednarz@gmail.com"]
   gem.description   = "Manage Mac development boxes with love (and Puppet)."
   gem.summary       = "You know, for laptops and stuff."
   gem.homepage      = "https://github.com/boxen/boxen"

--- a/boxen.gemspec
+++ b/boxen.gemspec
@@ -3,8 +3,8 @@
 Gem::Specification.new do |gem|
   gem.name          = "boxen"
   gem.version       = "2.9.0"
-  gem.authors       = ["John Barnette", "Will Farrington", "David Goodlad", "Mike McQuaid"]
-  gem.email         = ["jbarnette@github.com", "wfarr@github.com", "dgoodlad@github.com", "mikemcquaid@github.com"]
+  gem.authors       = ["John Barnette", "Will Farrington", "David Goodlad", "Jacob Bednarz"]
+  gem.email         = ["jbarnette@github.com", "wfarr@github.com", "dgoodlad@github.com", "jacob.bednarz@gmail.com"]
   gem.description   = "Manage Mac development boxes with love (and Puppet)."
   gem.summary       = "You know, for laptops and stuff."
   gem.homepage      = "https://github.com/boxen/boxen"

--- a/boxen.gemspec
+++ b/boxen.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "boxen"
-  gem.version       = "2.8.0"
+  gem.version       = "2.9.0"
   gem.authors       = ["John Barnette", "Will Farrington", "David Goodlad", "Mike McQuaid"]
   gem.email         = ["jbarnette@github.com", "wfarr@github.com", "dgoodlad@github.com", "mikemcquaid@github.com"]
   gem.description   = "Manage Mac development boxes with love (and Puppet)."


### PR DESCRIPTION
Updates Boxen to be at 2.9.0 and updates the author list to swap out
@MikeMcQuaid for @jacobbednarz.

cc @dgoodlad @wfarr @jbarnette for thoughts on author list addition.
If you disagree, I'm happy to drop the author and have one of you fine
folk push out the release.