### PR TITLE
Include boxen/util before using it

### DIFF
--- a/lib/boxen/config.rb
+++ b/lib/boxen/config.rb
@@ -1,5 +1,6 @@
 require "boxen/keychain"
 require "boxen/project"
+require "boxen/util"
 require "fileutils"
 require "json"
 require "octokit"


### PR DESCRIPTION
Fixes a problem introduced in https://github.com/boxen/boxen/pull/219

```
/opt/boxen/repo/.bundle/ruby/2.3.0/gems/boxen-3.1.1/lib/boxen/config.rb:28:in `block in load': uninitialized constant Boxen::Util (NameError)
	from /opt/boxen/repo/.bundle/ruby/2.3.0/gems/boxen-3.1.1/lib/boxen/config.rb:90:in `initialize'
	from /opt/boxen/repo/.bundle/ruby/2.3.0/gems/boxen-3.1.1/lib/boxen/config.rb:15:in `new'
	from /opt/boxen/repo/.bundle/ruby/2.3.0/gems/boxen-3.1.1/lib/boxen/config.rb:15:in `load'
	from /opt/boxen/bin/boxen-git-credential:31:in `<main>'
```